### PR TITLE
Fixed issue with configure method of SimpleBuilderSettings bug of overriding all setting values when only one was set.

### DIFF
--- a/src/Builder/SimpleSqlBuilder/Core/SimpleBuilderSettings.cs
+++ b/src/Builder/SimpleSqlBuilder/Core/SimpleBuilderSettings.cs
@@ -25,7 +25,7 @@ public static class SimpleBuilderSettings
     public static bool ReuseParameters { get; private set; } = DefaultReuseParameters;
 
     /// <summary>
-    /// Configures the Simple builder settings.
+    /// Configures the Simple builder settings. Null or empty arguments will be ignored.
     /// </summary>
     /// <param name="parameterNameTemplate">
     /// The parameter name template used to create the parameter names for the generated sql. The default is "p" so the parameter names will be generated as p0, p1, etc.
@@ -39,21 +39,21 @@ public static class SimpleBuilderSettings
     /// The value indicating whether to reuse parameters or not. The default value is <see langword="false"/>.
     /// <para>Example: If set to <see langword="true"/> parameters are reused and if set <see langword="false"/> to they are not.</para>
     /// </param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when new <paramref name="parameterNameTemplate"/> or <paramref name="parameterPrefix"/> <see langword="null"/>, <see cref="string.Empty"/> contains only white space.</exception>
-    public static void Configure(string parameterNameTemplate = DefaultDatabaseParameterNameTemplate, string parameterPrefix = DefaultDatabaseParameterPrefix, bool reuseParameters = DefaultReuseParameters)
+    public static void Configure(string? parameterNameTemplate = null, string? parameterPrefix = null, bool? reuseParameters = null)
     {
-        if (string.IsNullOrWhiteSpace(parameterNameTemplate))
+        if (!string.IsNullOrWhiteSpace(parameterNameTemplate))
         {
-            throw new ArgumentException($"'{nameof(parameterNameTemplate)}' cannot be null or whitespace.", nameof(parameterNameTemplate));
+            DatabaseParameterNameTemplate = parameterNameTemplate!;
         }
 
-        if (string.IsNullOrWhiteSpace(parameterPrefix))
+        if (!string.IsNullOrWhiteSpace(parameterPrefix))
         {
-            throw new ArgumentException($"'{nameof(parameterPrefix)}' cannot be null or whitespace.", nameof(parameterPrefix));
+            DatabaseParameterPrefix = parameterPrefix!;
         }
 
-        DatabaseParameterNameTemplate = parameterNameTemplate;
-        DatabaseParameterPrefix = parameterPrefix;
-        ReuseParameters = reuseParameters;
+        if (reuseParameters.HasValue)
+        {
+            ReuseParameters = reuseParameters.Value;
+        }
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/XUnit/PriorityOrderer.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/XUnit/PriorityOrderer.cs
@@ -1,0 +1,38 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Dapper.SimpleSqlBuilder.UnitTestHelpers.XUnit;
+
+public class PriorityOrderer : ITestCaseOrderer
+{
+    public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+        where TTestCase : ITestCase
+    {
+        string assemblyName = typeof(TestPriorityAttribute).AssemblyQualifiedName!;
+        var sortedMethods = new SortedDictionary<int, List<TTestCase>>();
+
+        foreach (TTestCase testCase in testCases)
+        {
+            int priority = testCase.TestMethod.Method
+                .GetCustomAttributes(assemblyName)
+                .FirstOrDefault()
+                ?.GetNamedArgument<int>(nameof(TestPriorityAttribute.Priority)) ?? 0;
+
+            GetOrCreate(sortedMethods, priority).Add(testCase);
+        }
+
+        foreach (TTestCase testCase in sortedMethods.Keys.SelectMany(priority => sortedMethods[priority].OrderBy(testCase => testCase.TestMethod.Method.Name)))
+        {
+            yield return testCase;
+        }
+    }
+
+    private static TValue GetOrCreate<TKey, TValue>(IDictionary<TKey, TValue> dictionary, TKey key)
+        where TKey : struct
+        where TValue : new()
+    {
+        return dictionary.TryGetValue(key, out TValue? result)
+            ? result
+            : (dictionary[key] = new TValue());
+    }
+}

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/XUnit/TestPriorityAttribute.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/XUnit/TestPriorityAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace Dapper.SimpleSqlBuilder.UnitTestHelpers.XUnit;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class TestPriorityAttribute : Attribute
+{
+    public TestPriorityAttribute(int priority)
+        => Priority = priority;
+
+    public int Priority { get; }
+}

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleBuilderSettingsTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleBuilderSettingsTests.cs
@@ -1,38 +1,14 @@
-﻿namespace Dapper.SimpleSqlBuilder.UnitTests.Core;
+﻿using Dapper.SimpleSqlBuilder.UnitTestHelpers.XUnit;
+
+namespace Dapper.SimpleSqlBuilder.UnitTests.Core;
 
 [Collection($"~ Run Last - {nameof(SimpleBuilderSettingsTests)}")]
+[TestCaseOrderer("Dapper.SimpleSqlBuilder.UnitTestHelpers.XUnit.PriorityOrderer", "Dapper.SimpleSqlBuilder.UnitTestHelpers")]
 public class SimpleBuilderSettingsTests
 {
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    public void Configure_ParameterNameTemplateIsNullOrWhiteSpace_ThrowsArgumentException(string parameterNameTemplate)
-    {
-        //Act
-        Action act = () => SimpleBuilderSettings.Configure(parameterNameTemplate);
-
-        //Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage($"'{nameof(parameterNameTemplate)}' cannot be null or whitespace.*")
-            .WithParameterName(nameof(parameterNameTemplate));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    public void Configure_ParameterPrefixIsNullOrWhiteSpace_ThrowsArgumentException(string parameterPrefix)
-    {
-        //Act
-        Action act = () => SimpleBuilderSettings.Configure(parameterPrefix: parameterPrefix);
-
-        //Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage($"'{nameof(parameterPrefix)}' cannot be null or whitespace.*")
-            .WithParameterName(nameof(parameterPrefix));
-    }
-
     [Fact]
-    public void Configure_DefaultValues_ReturnsVoid()
+    [TestPriority(1)]
+    public void Configure_NoArgumentsPassed_ReturnsVoid()
     {
         //Act
         SimpleBuilderSettings.Configure();
@@ -44,8 +20,9 @@ public class SimpleBuilderSettingsTests
     }
 
     [Theory]
+    [TestPriority(2)]
     [InlineData("param", ":", true)]
-    public void Configure_ConfigureSettings_ReturnsVoid(string parameterNameTemplate, string parameterPrefix, bool reuseParameters)
+    public void Configure_AllArgumentsPassed_ReturnsVoid(string parameterNameTemplate, string parameterPrefix, bool reuseParameters)
     {
         //Act
         SimpleBuilderSettings.Configure(parameterNameTemplate, parameterPrefix, reuseParameters);
@@ -54,5 +31,30 @@ public class SimpleBuilderSettingsTests
         SimpleBuilderSettings.DatabaseParameterNameTemplate.Should().Be(parameterNameTemplate);
         SimpleBuilderSettings.DatabaseParameterPrefix.Should().Be(parameterPrefix);
         SimpleBuilderSettings.ReuseParameters.Should().Be(reuseParameters);
+    }
+
+    [Theory]
+    [TestPriority(3)]
+    [InlineData("myParam", null, null, "myParam", "@", false)]
+    [InlineData("", ":", null, "prm", ":", false)]
+    [InlineData(null, null, true, "prm", "@", true)]
+    public void Configure_ConfigureSingleSetting_ReturnsVoid(
+        string? parameterNameTemplate,
+        string? parameterPrefix,
+        bool? reuseParameters,
+        string expectedParameterNameTemplate,
+        string expectedParameterPrefix,
+        bool expectedReuseParameters)
+    {
+        //Arrange
+        SimpleBuilderSettings.Configure("prm", "@", false);
+
+        //Act
+        SimpleBuilderSettings.Configure(parameterNameTemplate, parameterPrefix, reuseParameters);
+
+        //Assert
+        SimpleBuilderSettings.DatabaseParameterNameTemplate.Should().Be(expectedParameterNameTemplate);
+        SimpleBuilderSettings.DatabaseParameterPrefix.Should().Be(expectedParameterPrefix);
+        SimpleBuilderSettings.ReuseParameters.Should().Be(expectedReuseParameters);
     }
 }

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0",
+    "version": "1.1",
     "assemblyVersion": "1.0.0.0",
     "pathFilters": [ "!Benchmark", "!Tests" ],
     "versionHeightOffset": -1,


### PR DESCRIPTION
<!--Provide a concise title to the pull request as it will be used for the release documentation.-->

## Description
Fixed issue with configure method of `SimpleBuilderSettings` bug of overriding all setting values when only one was set. The method does not throw an exception anymore for null or empty values. 

<!--Please include a summary of the change and which issue is fixed or closed.-->
<!--Note any issues that are resolved in the is PR e.g. Closes #3213 or Fixes #3412 -->

## Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Other change

## Checklist
<!-- Ensure you have completed the checklist-->
- [ ] My change follows the guidelines outlined in the [contributing](https://github.com/mishael-o/Dapper.SimpleSqlBuilder/blob/main/docs/CONTRIBUTING.md) document.
