### PR TITLE
Migrated to central package management for NuGet packages, upgraded NuGet packages in library and bumped Dapper version to `2.1.35`

### DIFF
--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.18.1" />
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-        <PackageReference Include="Dapper.SqlBuilder" Version="2.0.78" />
+        <PackageReference Include="AutoFixture" />
+        <PackageReference Include="BenchmarkDotNet" />
+        <PackageReference Include="Dapper.SqlBuilder" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Builder/Directory.Build.props
+++ b/src/Builder/Directory.Build.props
@@ -28,8 +28,8 @@
     </PropertyGroup>
 
     <ItemGroup Label="PackageItemGroup">
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+        <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="All"/>
     </ItemGroup>
 
     <Target Name="OverrideVersion" AfterTargets="GetBuildVersion" Condition="'$(PublicRelease)' == 'False'">

--- a/src/Builder/SimpleSqlBuilder.DependencyInjection/SimpleSqlBuilder.DependencyInjection.csproj
+++ b/src/Builder/SimpleSqlBuilder.DependencyInjection/SimpleSqlBuilder.DependencyInjection.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
+++ b/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
@@ -15,12 +15,9 @@
         <Using Remove="System.Net.Http"></Using>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    </ItemGroup>
-
     <ItemGroup>
-      <PackageReference Include="Dapper.StrongName" Version="2.1.35" />
+      <PackageReference Include="Dapper.StrongName" />
+       <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'netstandard2.0'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
+++ b/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
@@ -12,12 +12,9 @@
         <Using Remove="System.Net.Http"></Using>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    </ItemGroup>
-
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.35" />
+        <PackageReference Include="Dapper" />
+        <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'netstandard2.0'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Dapper.SimpleSqlBuilder.sln
+++ b/src/Dapper.SimpleSqlBuilder.sln
@@ -88,6 +88,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3882C05C-BF9
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		version.json = version.json
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "images", "images", "{72D162B8-2003-41DF-9F04-483FDF95E7C2}"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,10 +10,6 @@
     </PropertyGroup>
 
     <ItemGroup Label="GlobalItemGroup">
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <AssemblyAttribute Include="System.CLSCompliantAttribute">
             <_Parameter1>false</_Parameter1>
         </AssemblyAttribute>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -29,6 +29,8 @@
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageVersion Include="Moq" Version="[4.18.4]" />
+        <!--For unit test issues on Linux https://github.com/microsoft/vstest/issues/2469-->
+        <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
     </ItemGroup>
 
     <ItemGroup Label="TestPackagesNETCore" Condition="'$(TargetFramework)' != 'net461'">
@@ -37,8 +39,6 @@
     </ItemGroup>
     
     <ItemGroup Label="TestPackagesNET461" Condition="'$(TargetFramework)' == 'net461'">
-        <!--For unit test issues on Linux https://github.com/microsoft/vstest/issues/2469-->
-        <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
         <PackageVersion Include="xunit" Version="2.4.2" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3"/>
     </ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,70 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    
+    <ItemGroup Label="GlobalPackages">
+        <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </GlobalPackageReference>
+    </ItemGroup>
+    
+    <ItemGroup Label="BuilderPackages">
+        <PackageVersion Include="Dapper" Version="2.1.35" />
+        <PackageVersion Include="Dapper.StrongName" Version="2.1.35" />
+        <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
+    </ItemGroup>
+    
+    <ItemGroup Label="TestPackages">
+        <PackageVersion Include="AutoFixture" Version="4.18.1" />
+        <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
+        <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+        <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageVersion Include="Moq" Version="[4.18.4]" />
+    </ItemGroup>
+
+    <ItemGroup Label="TestPackagesNETCore" Condition="'$(TargetFramework)' != 'net461'">
+        <PackageVersion Include="xunit" Version="2.8.0" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0"/>
+    </ItemGroup>
+    
+    <ItemGroup Label="TestPackagesNET461" Condition="'$(TargetFramework)' == 'net461'">
+        <!--For unit test issues on Linux https://github.com/microsoft/vstest/issues/2469-->
+        <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
+        <PackageVersion Include="xunit" Version="2.4.2" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3"/>
+    </ItemGroup>
+    
+    <ItemGroup Label="IntegrationTestPackages">
+        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+        <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+        <PackageVersion Include="TestContainers.MsSql" Version="3.8.0" />
+        <PackageVersion Include="TestContainers.MySql" Version="3.8.0" />
+        <PackageVersion Include="TestContainers.PostgreSql" Version="3.8.0" />
+    </ItemGroup>
+
+    <ItemGroup Label="IntegrationTestPackagesNETCore" Condition="'$(TargetFramework)' != 'net461'">
+        <PackageVersion Include="MySqlConnector" Version="2.3.7" />
+        <PackageVersion Include="Npgsql" Version="8.0.3" />
+        <PackageVersion Include="Respawn" Version="6.2.1" />
+    </ItemGroup>
+
+    <ItemGroup Label="IntegrationTestPackagesNET461" Condition="'$(TargetFramework)' == 'net461'">
+        <PackageVersion Include="MySqlConnector" Version="2.2.7" />
+        <PackageVersion Include="Npgsql" Version="6.0.11" />
+        <PackageVersion Include="Respawn" Version="4.0.0" />
+    </ItemGroup>
+    
+    <ItemGroup Label="BenchmarkPackages">
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
+        <PackageVersion Include="Dapper.SqlBuilder" Version="2.0.78" />
+    </ItemGroup>
+</Project>

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -16,6 +16,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition="'$(TargetFramework)' == 'net461'"/>
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" >
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -8,47 +8,28 @@
     </PropertyGroup>
 
     <ItemGroup Label="GlobalTestsItemGroup" Condition="'$(IsTestProject)' == 'true'">
-        <PackageReference Include="AutoFixture" Version="4.18.1" />
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="AutoFixture" />
+        <PackageReference Include="AutoFixture.Xunit2" />
+        <PackageReference Include="coverlet.collector" >
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" >
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <Using Include="AutoFixture" />
         <Using Include="AutoFixture.Xunit2" />
         <Using Include="FluentAssertions" />
         <Using Include="Xunit" />
     </ItemGroup>
 
-    <Choose>
-        <When Condition="'$(IsTestProject)' == 'true' And '$(TargetFramework)' != 'net461'">
-            <ItemGroup>
-                <PackageReference Include="xunit" Version="2.6.6" />
-                <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
-                    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-                    <PrivateAssets>all</PrivateAssets>
-                </PackageReference>
-            </ItemGroup>
-        </When>
-        <When Condition="'$(IsTestProject)' == 'true' And '$(TargetFramework)' == 'net461'">
-            <ItemGroup>
-                <PackageReference Include="xunit" Version="2.4.2" />
-                <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-                    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-                    <PrivateAssets>all</PrivateAssets>
-                </PackageReference>
-
-                <!--For unit test issues on Linux https://github.com/microsoft/vstest/issues/2469-->
-                <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
-            </ItemGroup>
-        </When>
-    </Choose>
-
     <ItemGroup Label="UnitTestsItemGroup" Condition="'$(IsUnitTestProject)' == 'true'">
-        <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-        <PackageReference Include="Moq" Version="[4.18.4]" />
+        <PackageReference Include="AutoFixture.AutoMoq" />
+        <PackageReference Include="Moq" />
         <Using Include="AutoFixture.AutoMoq" />
         <Using Include="Moq" />
     </ItemGroup>

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTestsFixture.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTestsFixture.cs
@@ -71,7 +71,7 @@ public class MySqlTestsFixture : IAsyncLifetime
             .WithPassword(dbPassword)
             .WithPortBinding(Port)
             .WithName("mysql")
-            .WithImage("mysql:8.2")
+            .WithImage("mysql:8.4")
             .Build();
     }
 

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
@@ -5,25 +5,16 @@
         <RootNamespace>Dapper.SimpleSqlBuilder.IntegrationTests</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.IntegrationTests</AssemblyName>
     </PropertyGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-        <PackageReference Include="MySqlConnector" Version="2.2.7" />
-        <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-        <PackageReference Include="Npgsql" Version="6.0.8" />
-        <PackageReference Include="Respawn" Version="4.0.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
-        <PackageReference Include="MySqlConnector" Version="2.3.5" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
-        <PackageReference Include="Npgsql" Version="8.0.1" />
-        <PackageReference Include="Respawn" Version="6.2.1" />
-    </ItemGroup>
-
+    
     <ItemGroup>
-        <PackageReference Include="TestContainers.MsSql" Version="3.7.0" />
-        <PackageReference Include="TestContainers.MySql" Version="3.7.0" />
-        <PackageReference Include="TestContainers.PostgreSql" Version="3.7.0" />
+        <PackageReference Include="MySqlConnector" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)' != 'net461'" />
+        <PackageReference Include="Npgsql" />
+        <PackageReference Include="Respawn" />
+        <PackageReference Include="System.Data.SqlClient" Condition="'$(TargetFramework)' == 'net461'"/>
+        <PackageReference Include="TestContainers.MsSql" />
+        <PackageReference Include="TestContainers.MySql" />
+        <PackageReference Include="TestContainers.PostgreSql" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests.csproj
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "3.6",
+    "version": "3.7",
     "assemblyVersion": "3.0.0.0",
     "pathFilters": [ ":!Benchmark", ":!Tests" ],
     "versionHeightOffset": -1,


### PR DESCRIPTION
## Description
Migrated to central package management and updated Nuget packages and docker images.

List of changes:

1. Package version numbers have been removed from project files and are now managed centrally in the `Directory.Packages.props` file.
2. The `StyleCop.Analyzers` package reference has been moved from the `Directory.Build.props` file to the `Directory.Packages.props` file.
3. The `xunit` and `xunit.runner.visualstudio` package references have been moved from the `Choose` element in the `Directory.Build.props` file to the `ItemGroup` for test projects in the `Directory.Packages.props` file.
4. The MySQL image version in the `MySqlTestsFixture.cs` file has been updated from `8.2` to `8.4`.
5. The project version in the `version.json` file has been updated from `3.6` to `3.7`.
6. A new file, `Directory.Packages.props`, has been added to manage package versions centrally. It includes various item groups with package references and their respective versions.

## Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Hotfix (a major bugfix that has to be merged asap)
- [ ] Other change

## Checklist
<!-- Ensure you have completed the checklist-->
- [x] My change follows the guidelines outlined in the [contributing](https://github.com/mishael-o/Dapper.SimpleSqlBuilder/blob/main/docs/CONTRIBUTING.md) document.
