### PR TITLE
`NET 7.0` framework is no longer being targeted as it has reached EOL

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install dotnet-coverage
         run: dotnet tool install --global dotnet-coverage
       - name: Merge coverage reports
-        run: dotnet-coverage merge ${{ env.coverageReportPath }}/**/*.xml -f cobertura -o ${{ env.coverageReportPath }}${{ env.mergedCoverageReportFileName }}
+        run: dotnet-coverage merge ${{ env.coverageReportPath }}**/*.xml -f cobertura -o ${{ env.coverageReportPath }}${{ env.mergedCoverageReportFileName }}
       - name: Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,10 +45,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
-      - name: Setup .NET 7
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 7.x
       - name: Setup .NET 6
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install dotnet-coverage
         run: dotnet tool install --global dotnet-coverage
       - name: Merge coverage reports
-        run: dotnet-coverage merge ${{ env.coverageReportPath }}*.xml --recursive -f cobertura -o ${{ env.coverageReportPath }}${{ env.mergedCoverageReportFileName }}
+        run: dotnet-coverage merge ${{ env.coverageReportPath }}/**/*.xml -f cobertura -o ${{ env.coverageReportPath }}${{ env.mergedCoverageReportFileName }}
       - name: Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net461;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Builder/Directory.Build.props
+++ b/src/Builder/Directory.Build.props
@@ -28,8 +28,8 @@
     </PropertyGroup>
 
     <ItemGroup Label="PackageItemGroup">
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-        <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="All" />
     </ItemGroup>
 
     <Target Name="OverrideVersion" AfterTargets="GetBuildVersion" Condition="'$(PublicRelease)' == 'False'">

--- a/src/Builder/SimpleSqlBuilder.DependencyInjection/SimpleSqlBuilder.DependencyInjection.csproj
+++ b/src/Builder/SimpleSqlBuilder.DependencyInjection/SimpleSqlBuilder.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
         <RootNamespace>Dapper.SimpleSqlBuilder.DependencyInjection</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.DependencyInjection</AssemblyName>
         <Description>Dependency injection extension for Dapper.SimpleSqlBuilder.</Description>

--- a/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
+++ b/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net461;netstandard2.0;net6.0;net8.0</TargetFrameworks>
         <Description>A simple SQL builder for Dapper using string interpolation and fluent API for building safe static and dynamic SQL queries.</Description>
         <RootNamespace>Dapper.SimpleSqlBuilder.StrongName</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.StrongName</AssemblyName>

--- a/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
+++ b/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net461;netstandard2.0;net6.0;net8.0</TargetFrameworks>
         <Description>A simple SQL builder for Dapper using string interpolation and fluent API for building safe static and dynamic SQL queries.</Description>
         <RootNamespace>Dapper.SimpleSqlBuilder</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder</AssemblyName>

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
         <RootNamespace>Dapper.SimpleSqlBuilder.IntegrationTests</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.IntegrationTests</AssemblyName>
     </PropertyGroup>

--- a/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests.csproj
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <IsUnitTestProject>true</IsUnitTestProject>
         <RootNamespace>Dapper.SimpleSqlBuilder.DependencyInjection.UnitTests</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.DependencyInjection.UnitTests</AssemblyName>

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/SimpleSqlBuilder.UnitTestHelpers.csproj
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/SimpleSqlBuilder.UnitTestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <TargetFrameworks>net461;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
         <IsUnitTestProject>true</IsUnitTestProject>
         <RootNamespace>Dapper.SimpleSqlBuilder.UnitTestHelpers</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.UnitTestHelpers</AssemblyName>

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/SimpleSqlBuilder.UnitTests.csproj
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/SimpleSqlBuilder.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
         <IsUnitTestProject>true</IsUnitTestProject>
         <RootNamespace>Dapper.SimpleSqlBuilder.UnitTests</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.UnitTests</AssemblyName>


### PR DESCRIPTION
## Description

`NET 7.0` framework is no longer being targeted as it has reached EOL.

## Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Hotfix (a major bugfix that has to be merged asap)
- [x] Other change

## Checklist
<!-- Ensure you have completed the checklist-->
- [x] My change follows the guidelines outlined in the [contributing](https://github.com/mishael-o/Dapper.SimpleSqlBuilder/blob/main/docs/CONTRIBUTING.md) document.
