### PR TITLE
Refined docs and updated MySQL test version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![Dapper Simple SQL Builder](https://raw.githubusercontent.com/mishael-o/Dapper.SimpleSqlBuilder/main/images/readme-icon.png)
 
-A simple SQL builder for [Dapper](https://github.com/DapperLib/Dapper) using [string interpolation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated) and fluent API for building safe static and dynamic SQL queries.
+A simple SQL builder for [Dapper](https://github.com/DapperLib/Dapper), using [string interpolation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated) and a fluent API to build safe, static, and dynamic SQL queries.
 
 ## Getting Started
 

--- a/docs/github-pages/docs/advanced-features/reusing-parameters.md
+++ b/docs/github-pages/docs/advanced-features/reusing-parameters.md
@@ -23,11 +23,11 @@ AND Age <= {maxAge}");
 // OR
 
 // Configuring per-builder instance
-var secondBuilder = SimpleBuilder.Create($@"
-SELECT x.*, (SELECT Type FROM UserType WHERE Id = @p0) AS UserType
+builder = SimpleBuilder.Create($@"
+SELECT x.*, (SELECT Type FROM UserType WHERE Id = {userTypeId}) AS UserType
 FROM User x
-WHERE UserTypeId = @p0
-AND Age <= @p1",
+WHERE UserTypeId = {userTypeId}
+AND Age <= {maxAge}",
 reuseParameters: true);
 ```
 

--- a/docs/github-pages/docs/builders/dapper-comparison.md
+++ b/docs/github-pages/docs/builders/dapper-comparison.md
@@ -1,8 +1,8 @@
 # Comparison to Dapper
 
-The code snippets below show how the library compares to Dapper and Dapper's SqlBuilder when writing SQL queries. For performance comparisons, see the [Performance](../miscellaneous/performance.md) section.
+The code snippets below illustrate how this library compares to Dapper and Dapper's SqlBuilder in building SQL queries. For performance comparisons, refer to the [Performance](../miscellaneous/performance.md) section.
 
-The code is extracting data from a `Users` table where the `UserTypeId` is equal to a given `userTypeId` and the `Role` is equal to a given `role`.
+The examples demonstrate extracting data from a `Users` table where `UserTypeId` equals a specified `userTypeId` and `Role` matches a specified `role`.
 
 ## [Dapper](#tab/dapper)
 

--- a/docs/github-pages/docs/configuration/builder-settings.md
+++ b/docs/github-pages/docs/configuration/builder-settings.md
@@ -72,5 +72,5 @@ SimpleBuilderSettings.Configure(useLowerCaseClauses: true);
 This can also be configured per fluent builder instance if you want to override the global settings.
 
 ```csharp
-var builder = SimpleBuilder.CreateFluent(useLowerCaseClauses: true);
+var fluentBuilder = SimpleBuilder.CreateFluent(useLowerCaseClauses: true);
 ```

--- a/docs/github-pages/docs/configuration/dependency-injection.md
+++ b/docs/github-pages/docs/configuration/dependency-injection.md
@@ -31,7 +31,7 @@ class MyClass
     public void MyMethod2()
     {
         int id = 10;
-        var builder = simpleBuilder.CreateFluent()
+        var fluentBuilder = simpleBuilder.CreateFluent()
             .Select($"*")
             .From($"User")
             .Where($"Id = {id}");

--- a/docs/github-pages/docs/introduction.md
+++ b/docs/github-pages/docs/introduction.md
@@ -17,13 +17,13 @@
 The library provides two builders for building SQL queries:
 
 - [Builder](builders/builder.md) - for building static, dynamic and complex SQL queries.
-- [Fluent Builder](builders/fluent-builder/fluent-builder.md) - for building dynamic SQL queries using fluent API.
+- [Fluent Builder](builders/fluent-builder/fluent-builder.md) - for building dynamic SQL queries using a fluent API.
 
 ## Packages
 
 The library provides multiple packages to suit your needs.
 
-[Dapper.SimpleSqlBuilder](https://www.nuget.org/packages/Dapper.SimpleSqlBuilder): A simple SQL builder for Dapper using string interpolation and fluent API for building safe static and dynamic SQL queries.
+[Dapper.SimpleSqlBuilder](https://www.nuget.org/packages/Dapper.SimpleSqlBuilder): A simple SQL builder for Dapper, using string interpolation and a fluent API to build safe, static, and dynamic SQL queries.
 
 [![Nuget](https://img.shields.io/nuget/v/Dapper.SimpleSqlBuilder?logo=nuget)](https://www.nuget.org/packages/Dapper.SimpleSqlBuilder) [![Nuget](https://img.shields.io/nuget/dt/Dapper.SimpleSqlBuilder?logo=nuget)](https://www.nuget.org/packages/Dapper.SimpleSqlBuilder)
 

--- a/docs/github-pages/index.md
+++ b/docs/github-pages/index.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-A simple SQL builder for [Dapper](https://github.com/DapperLib/Dapper) using [string interpolation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated) and fluent API for building safe static and dynamic SQL queries.
+A simple SQL builder for [Dapper](https://github.com/DapperLib/Dapper), using [string interpolation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated) and a fluent API to build safe, static, and dynamic SQL queries.
 
 ## Installation
 
@@ -23,7 +23,7 @@ dotnet add package Dapper.SimpleSqlBuilder
 The library provides two builders for building SQL queries, which can be created via the static `SimpleBuilder` class.
 
 - `Builder` - for building static, dynamic, and complex SQL queries.
-- `Fluent Builder` - for building SQL queries using fluent API.
+- `Fluent Builder` - for building SQL queries using a fluent API.
 
  The library also provides an alternative to static classes via [Dependency Injection](docs/configuration/dependency-injection.md).
 

--- a/src/Builder/SimpleSqlBuilder.DependencyInjection/Core/SimpleBuilderOptions.cs
+++ b/src/Builder/SimpleSqlBuilder.DependencyInjection/Core/SimpleBuilderOptions.cs
@@ -14,10 +14,10 @@ public sealed class SimpleBuilderOptions
     private string databaseParameterPrefix = SimpleBuilderSettings.DefaultDatabaseParameterPrefix;
 
     /// <summary>
-    /// Gets or sets the parameter name template used to create the parameter names for the generated SQL. The default is "p" so the parameter names will be generated as p0, p1, etc.
-    /// <para>Example: If you set the template to "param" it will generate param0, param1, etc.</para>
+    /// Gets or sets the parameter name template used to create the parameter names for the generated SQL. The default is <c>p</c>, so the parameter names will be generated as <c>p0</c>, <c>p1</c>, etc.
+    /// <para>Example: If you set the template to <c>param</c>, it will generate <c>param0</c>, <c>param1</c>, etc.</para>
     /// </summary>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when new value is <see langword="null"/>, <see cref="string.Empty"/>, or contains only white-space.</exception>
+    /// <exception cref="ArgumentException">Thrown when new value is <see langword="null"/>, <see cref="string.Empty"/>, or contains only white-space.</exception>
     public string DatabaseParameterNameTemplate
     {
         get => databaseParameterNameTemplate;
@@ -33,10 +33,10 @@ public sealed class SimpleBuilderOptions
     }
 
     /// <summary>
-    /// Gets or sets the parameter prefix used in the rendered SQL. The default is "@", so you will get @p0, @p1, etc.
-    /// <para>Example: If you set the parameter prefix to ":" it will generate :p0, :p1, etc.</para>
+    /// Gets or sets the parameter prefix used in the rendered SQL. The default is <c>@</c>, so you will get <c>@p0</c>, <c>@p1</c>, etc.
+    /// <para>Example: If you set the parameter prefix to <c>:</c>, it will generate <c>:p0</c>, <c>:p1</c>, etc.</para>
     /// </summary>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when new value is <see langword="null"/>, <see cref="string.Empty"/>, or contains only white-space.</exception>
+    /// <exception cref="ArgumentException">Thrown when new value is <see langword="null"/>, <see cref="string.Empty"/>, or contains only white-space.</exception>
     public string DatabaseParameterPrefix
     {
         get => databaseParameterPrefix;
@@ -58,8 +58,8 @@ public sealed class SimpleBuilderOptions
     public bool ReuseParameters { get; set; } = SimpleBuilderSettings.DefaultReuseParameters;
 
     /// <summary>
-    /// Get the value indicating whether SQL clauses should be in upper case or lower case. The default value is <see langword="false"/> meaning SQL clauses will be in upper cases. i.e. SELECT, UPDATE, etc.
-    /// <para>Example: If set to <see langword="true"/>, SQL clauses will be in lower cases i.e. select, update, etc.</para>
+    /// Get the value indicating whether SQL clauses should be in upper case or lower case. The default value is <see langword="false"/> meaning SQL clauses will be in upper cases. i.e. <c>SELECT</c>, <c>UPDATE</c>, etc.
+    /// <para>Example: If set to <see langword="true"/>, SQL clauses will be in lower cases i.e. <c>select</c>, <c>update</c>, etc.</para>
     /// </summary>
     public bool UseLowerCaseClauses { get; set; } = SimpleBuilderSettings.DefaultUseLowerCaseClauses;
 }

--- a/src/Builder/SimpleSqlBuilder.DependencyInjection/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Builder/SimpleSqlBuilder.DependencyInjection/Extensions/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ public static class ServiceCollectionExtensions
     /// <param name="service">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="serviceLifetime">The <see cref="ServiceLifetime"/> for the <see cref="ISimpleBuilder"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
-    /// <exception cref="ArgumentNullException">Throws an <see cref="ArgumentNullException"/> when <paramref name="service"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddSimpleSqlBuilder(this IServiceCollection service, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
         return service
@@ -28,7 +28,7 @@ public static class ServiceCollectionExtensions
     /// <param name="configure">The action to configure the <see cref="SimpleBuilderOptions"/>.</param>
     /// <param name="serviceLifetime">The <see cref="ServiceLifetime"/> for the <see cref="ISimpleBuilder"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
-    /// <exception cref="ArgumentNullException">Throws an <see cref="ArgumentNullException"/> when <paramref name="service"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddSimpleSqlBuilder(this IServiceCollection service, Action<SimpleBuilderOptions> configure, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
         if (service is null)
@@ -56,9 +56,7 @@ public static class ServiceCollectionExtensions
     /// <param name="configurationSectionPath">The name of the configuration section to bind to the <see cref="SimpleBuilderOptions"/>.</param>
     /// <param name="serviceLifetime">The <see cref="ServiceLifetime"/> for the <see cref="ISimpleBuilder"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// Throws an <see cref="ArgumentNullException"/> when <paramref name="service"/> is <see langword="null"/> or when <paramref name="configurationSectionPath"/> is <see langword="null"/>, empty or white-space.
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service"/> is <see langword="null"/> or when <paramref name="configurationSectionPath"/> is <see langword="null"/>, empty or white-space.</exception>
     public static IServiceCollection AddSimpleSqlBuilder(this IServiceCollection service, string configurationSectionPath, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
         if (service is null)

--- a/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
+++ b/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net461;netstandard2.0;net6.0;net8.0</TargetFrameworks>
-        <Description>A simple SQL builder for Dapper using string interpolation and fluent API for building safe static and dynamic SQL queries.</Description>
+        <Description>A simple SQL builder for Dapper, using string interpolation and a fluent API to build safe, static, and dynamic SQL queries.</Description>
         <RootNamespace>Dapper.SimpleSqlBuilder.StrongName</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.StrongName</AssemblyName>
         <Title>Dapper SimpleSqlBuilder StrongName</Title>
@@ -17,7 +17,7 @@
 
     <ItemGroup>
       <PackageReference Include="Dapper.StrongName" />
-       <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'netstandard2.0'"/>
+      <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'netstandard2.0'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Builder/SimpleSqlBuilder/Core/Builder.cs
+++ b/src/Builder/SimpleSqlBuilder/Core/Builder.cs
@@ -22,7 +22,7 @@ public abstract class Builder : ISqlBuilder
     /// <param name="builder">The <see cref="Builder"/> instance to perform the operation on.</param>
     /// <param name="formattable">The <see cref="FormattableString"/>.</param>
     /// <returns>The <see cref="Builder"/> instance.</returns>
-    /// <exception cref="ArgumentNullException">Throws an <see cref="ArgumentNullException"/> when called on a <see langword="null"/> object.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when called on a <see langword="null"/> object.</exception>
     public static Builder operator +(Builder builder, FormattableString formattable)
     {
         return builder is null

--- a/src/Builder/SimpleSqlBuilder/Core/Handlers/AppendIntactInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/Core/Handlers/AppendIntactInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct AppendIntactInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
     public AppendIntactInterpolatedStringHandler(int literalLength, int formattedCount, Builder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +30,7 @@ public ref struct AppendIntactInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
     public AppendIntactInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, Builder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/Core/Handlers/AppendInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/Core/Handlers/AppendInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct AppendInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
     public AppendInterpolatedStringHandler(int literalLength, int formattedCount, Builder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +30,7 @@ public ref struct AppendInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
     public AppendInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, Builder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/Core/Handlers/AppendNewLineInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/Core/Handlers/AppendNewLineInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct AppendNewLineInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
     public AppendNewLineInterpolatedStringHandler(int literalLength, int formattedCount, Builder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +30,7 @@ public ref struct AppendNewLineInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IBuilderFormatter"/>.</exception>
     public AppendNewLineInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, Builder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/Core/SimpleBuilderSettings.cs
+++ b/src/Builder/SimpleSqlBuilder/Core/SimpleBuilderSettings.cs
@@ -53,20 +53,20 @@ public sealed class SimpleBuilderSettings
     /// Configures the builders settings. Null or empty arguments will be ignored.
     /// </summary>
     /// <param name="parameterNameTemplate">
-    /// The parameter name template used to create the parameter names for the generated SQL. The default is "p" so the parameter names will be generated as p0, p1, etc.
-    /// <para>Example: If you set the template to "param" it will generate param0, param1, etc.</para>
+    /// The parameter name template used to create the parameter names for the generated SQL. The default is <c>p</c>, so the parameter names will be generated as <c>p0</c> , <c>p1</c>, etc.
+    /// <para>Example: If you set the template to <c>param</c>, it will generate <c>param0</c>, <c>param1</c>, etc.</para>
     /// </param>
     /// <param name="parameterPrefix">
-    /// The parameter prefix used in the rendered SQL. The default is "@", so you will get @p0, @p1, etc.
-    /// <para>Example: If you set the parameter prefix to ":" it will generate :p0, :p1, etc.</para>
+    /// The parameter prefix used in the rendered SQL. The default is <c>@</c>, so you will get <c>@p0</c>, <c>@p1</c>, etc.
+    /// <para>Example: If you set the parameter prefix to <c>:</c>, it will generate <c>:p0</c>, <c>:p1</c>, etc.</para>
     /// </param>
     /// <param name="reuseParameters">
     /// The value indicating whether to reuse parameters or not. The default value is <see langword="false"/>.
     /// <para>Example: If set to <see langword="true"/> parameters are reused and if set <see langword="false"/> to they are not.</para>
     /// </param>
     /// <param name="useLowerCaseClauses">
-    /// The value indicating whether to use lower case clauses for the fluent builder. The default value is <see langword="false"/> meaning SQL clauses will be in upper cases. i.e. SELECT, UPDATE, etc.
-    /// <para>Example: If set to <see langword="true"/>, SQL clauses will be in lower cases i.e. select, update, etc.</para>
+    /// The value indicating whether to use lower case clauses for the fluent builder. The default value is <see langword="false"/> meaning SQL clauses will be in upper cases. i.e. <c>SELECT</c>, <c>UPDATE</c>, etc.
+    /// <para>Example: If set to <see langword="true"/>, SQL clauses will be in lower cases i.e. <c>select</c>, <c>update</c>, etc.</para>
     /// <para>The <paramref name="useLowerCaseClauses"/> is only applicable to the fluent builder.</para>
     /// </param>
     public static void Configure(string? parameterNameTemplate = null, string? parameterPrefix = null, bool? reuseParameters = null, bool? useLowerCaseClauses = null)

--- a/src/Builder/SimpleSqlBuilder/Extensions/SimpleParameterInfoExtensions.cs
+++ b/src/Builder/SimpleSqlBuilder/Extensions/SimpleParameterInfoExtensions.cs
@@ -17,7 +17,7 @@ public static class SimpleParameterInfoExtensions
     /// <param name="precision">The parameter precision.</param>
     /// <param name="scale">The parameter scale.</param>
     /// <returns>An new instance of <see cref="ISimpleParameterInfo"/>.</returns>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when called on <see cref="ISimpleParameterInfo"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when called on <see cref="ISimpleParameterInfo"/>.</exception>
     public static ISimpleParameterInfo DefineParam<T>(this T value, DbType? dbType = null, int? size = null, byte? precision = null, byte? scale = null)
     {
         return value is ISimpleParameterInfo

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Builders/DeleteBuilders/IDeleteBuilderEntry.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Builders/DeleteBuilders/IDeleteBuilderEntry.cs
@@ -11,6 +11,7 @@ public interface IDeleteBuilderEntry
     /// </summary>
     /// <param name="handler">The handler for the interpolated string.</param>
     /// <returns>The <see cref="IDeleteBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>DeleteFrom</c> and <c>Select</c> on the same builder instance.</exception>
     IDeleteBuilder DeleteFrom([InterpolatedStringHandlerArgument("")] ref DeleteInterpolatedStringHandler handler);
 #else
 
@@ -19,6 +20,7 @@ public interface IDeleteBuilderEntry
     /// </summary>
     /// <param name="formattable">The <see cref="FormattableString"/>.</param>
     /// <returns>The <see cref="IDeleteBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>DeleteFrom</c> and <c>Select</c> on the same builder instance.</exception>
     IDeleteBuilder DeleteFrom(FormattableString formattable);
 
 #endif

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Builders/InsertBuilders/IInsertBuilderEntry.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Builders/InsertBuilders/IInsertBuilderEntry.cs
@@ -11,6 +11,7 @@ public interface IInsertBuilderEntry
     /// </summary>
     /// <param name="handler">The handler for the interpolated string.</param>
     /// <returns>The <see cref="IInsertBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>InsertInto</c> and <c>DeleteFrom</c> on the same builder instance.</exception>
     IInsertBuilder InsertInto([InterpolatedStringHandlerArgument("")] ref InsertInterpolatedStringHandler handler);
 #else
 
@@ -19,6 +20,7 @@ public interface IInsertBuilderEntry
     /// </summary>
     /// <param name="formattable">The <see cref="FormattableString"/>.</param>
     /// <returns>The <see cref="IInsertBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>InsertInto</c> and <c>DeleteFrom</c> on the same builder instance.</exception>
     IInsertBuilder InsertInto(FormattableString formattable);
 
 #endif

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Builders/SelectBuilders/ISelectBuilderEntry.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Builders/SelectBuilders/ISelectBuilderEntry.cs
@@ -11,6 +11,7 @@ public interface ISelectBuilderEntry
     /// </summary>
     /// <param name="handler">The handler for the interpolated string.</param>
     /// <returns>The <see cref="ISelectBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>Select</c> and <c>SelectDistinct</c> on the same builder instance.</exception>
     ISelectBuilder Select([InterpolatedStringHandlerArgument("")] ref SelectInterpolatedStringHandler handler);
 
     /// <summary>
@@ -18,6 +19,7 @@ public interface ISelectBuilderEntry
     /// </summary>
     /// <param name="handler">The handler for the interpolated string.</param>
     /// <returns>The <see cref="ISelectDistinctBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>SelectDistinct</c> and <c>Select</c> on the same builder instance.</exception>
     ISelectDistinctBuilder SelectDistinct([InterpolatedStringHandlerArgument("")] ref SelectDistinctInterpolatedStringHandler handler);
 #else
 
@@ -26,6 +28,7 @@ public interface ISelectBuilderEntry
     /// </summary>
     /// <param name="formattable">The <see cref="FormattableString"/>.</param>
     /// <returns>The <see cref="ISelectBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>Select</c> and <c>SelectDistinct</c> on the same builder instance.</exception>
     ISelectBuilder Select(FormattableString formattable);
 
     /// <summary>
@@ -33,6 +36,7 @@ public interface ISelectBuilderEntry
     /// </summary>
     /// <param name="formattable">The <see cref="FormattableString"/>.</param>
     /// <returns>The <see cref="ISelectDistinctBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>SelectDistinct</c> and <c>Select</c> on the same builder instance.</exception>
     ISelectDistinctBuilder SelectDistinct(FormattableString formattable);
 
 #endif

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Builders/UpdateBuilders/IUpdateBuilderEntry.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Builders/UpdateBuilders/IUpdateBuilderEntry.cs
@@ -11,6 +11,7 @@ public interface IUpdateBuilderEntry
     /// </summary>
     /// <param name="handler">The handler for the interpolated string.</param>
     /// <returns>The <see cref="IUpdateBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>Update</c> and <c>InsertInto</c> on the same builder instance.</exception>
     IUpdateBuilder Update([InterpolatedStringHandlerArgument("")] ref UpdateInterpolatedStringHandler handler);
 #else
 
@@ -19,6 +20,7 @@ public interface IUpdateBuilderEntry
     /// </summary>
     /// <param name="formattable">The <see cref="FormattableString"/>.</param>
     /// <returns>The <see cref="IUpdateBuilder"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when two entry clauses are called on the same instance, e.g., calling <c>Update</c> and <c>InsertInto</c> on the same builder instance.</exception>
     IUpdateBuilder Update(FormattableString formattable);
 
 #endif

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/DeleteInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/DeleteInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct DeleteInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public DeleteInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/GroupByInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/GroupByInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct GroupByInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public GroupByInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct GroupByInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public GroupByInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/HavingInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/HavingInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct HavingInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public HavingInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct HavingInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public HavingInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/InnerJoinInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/InnerJoinInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct InnerJoinInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public InnerJoinInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct InnerJoinInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public InnerJoinInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/InsertColumnInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/InsertColumnInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct InsertColumnInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public InsertColumnInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/InsertInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/InsertInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct InsertInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public InsertInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/InsertValueInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/InsertValueInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct InsertValueInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public InsertValueInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/LeftJoinInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/LeftJoinInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct LeftJoinInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public LeftJoinInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct LeftJoinInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public LeftJoinInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/OrderByInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/OrderByInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct OrderByInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public OrderByInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct OrderByInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public OrderByInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/RightJoinInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/RightJoinInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct RightJoinInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public RightJoinInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct RightJoinInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public RightJoinInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/SelectDistinctInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/SelectDistinctInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct SelectDistinctInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public SelectDistinctInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/SelectFromInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/SelectFromInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct SelectFromInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public SelectFromInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/SelectInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/SelectInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct SelectInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public SelectInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/UpdateInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/UpdateInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct UpdateInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public UpdateInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/UpdateSetInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/UpdateSetInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct UpdateSetInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public UpdateSetInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct UpdateSetInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public UpdateSetInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereFilterInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereFilterInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct WhereFilterInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereFilterInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct WhereInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct WhereInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereOrFilterInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereOrFilterInterpolatedStringHandler.cs
@@ -16,7 +16,7 @@ public ref struct WhereOrFilterInterpolatedStringHandler
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereOrFilterInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder)
     {
         formatter = builder as IFluentBuilderFormatter

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereOrInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereOrInterpolatedStringHandler.cs
@@ -30,7 +30,7 @@ public ref struct WhereOrInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereOrInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereWithFilterInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereWithFilterInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct WhereWithFilterInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereWithFilterInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct WhereWithFilterInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereWithFilterInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereWithOrFilterInterpolatedStringHandler.cs
+++ b/src/Builder/SimpleSqlBuilder/FluentBuilder/Handlers/WhereWithOrFilterInterpolatedStringHandler.cs
@@ -17,6 +17,7 @@ public ref struct WhereWithOrFilterInterpolatedStringHandler
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereWithOrFilterInterpolatedStringHandler(int literalLength, int formattedCount, IFluentBuilder builder, out bool isHandlerEnabled)
         : this(literalLength, formattedCount, true, builder, out isHandlerEnabled)
     {
@@ -30,7 +31,7 @@ public ref struct WhereWithOrFilterInterpolatedStringHandler
     /// <param name="condition">The value to determine whether the handler should be enabled or disabled.</param>
     /// <param name="builder">The fluent builder associated with the handler.</param>
     /// <param name="isHandlerEnabled">The value that indicates whether the handler is enabled or disabled.</param>
-    /// <exception cref="ArgumentException">Throws an <see cref="ArgumentException"/> when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="builder"/> is <see langword="null"/> or doesn't implement <see cref="IFluentBuilderFormatter"/>.</exception>
     public WhereWithOrFilterInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, IFluentBuilder builder, out bool isHandlerEnabled)
     {
         if (!condition)

--- a/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
+++ b/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
@@ -2,7 +2,7 @@
     
     <PropertyGroup>
         <TargetFrameworks>net461;netstandard2.0;net6.0;net8.0</TargetFrameworks>
-        <Description>A simple SQL builder for Dapper using string interpolation and fluent API for building safe static and dynamic SQL queries.</Description>
+        <Description>A simple SQL builder for Dapper, using string interpolation and a fluent API to build safe, static, and dynamic SQL queries.</Description>
         <RootNamespace>Dapper.SimpleSqlBuilder</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder</AssemblyName>
         <Title>Dapper SimpleSqlBuilder</Title>

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTestsFixture.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTestsFixture.cs
@@ -71,7 +71,7 @@ public class MySqlTestsFixture : IAsyncLifetime
             .WithPassword(dbPassword)
             .WithPortBinding(Port)
             .WithName("mysql")
-            .WithImage("mysql:8.4")
+            .WithImage("mysql:9")
             .Build();
     }
 


### PR DESCRIPTION
## Description

Refine docs and update MySQL test version:

- Updated README.md to better describe the library's features, focusing on string interpolation and a fluent API for SQL queries.
- Improved variable naming and examples in `reusing-parameters.md` and made language refinements in `dapper-comparison.md`.
- Made variable naming consistent in `builder-settings.md` by changing `builder` to `fluentBuilder`.
- Enhanced the introduction and Quick Start guide to highlight the fluent API and string interpolation usage.
- Updated documentation comments across various files for clarity and consistency, especially regarding exception documentation and default values.
- Standardized exception documentation language across multiple files, changing "Throws" to "Thrown".
- Added clear documentation for potential `InvalidOperationException` in builder interfaces to clarify behaviour when conflicting entry clauses are used.
- Updated the project description in `SimpleSqlBuilder.StrongName.csproj` for clarity and alignment with README changes.
- Updated MySQL Docker image version in `MySqlTestsFixture` to "mysql:9" for testing with the latest MySQL version.

## Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Hotfix (a major bugfix that has to be merged asap)
- [x] Other change

## Checklist
<!-- Ensure you have completed the checklist-->
- [x] My change follows the guidelines outlined in the [contributing](https://github.com/mishael-o/Dapper.SimpleSqlBuilder/blob/main/docs/CONTRIBUTING.md) document.
