### PR TITLE
Autofix: Could you provide an InnerJoin example?

### DIFF
--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/SelectBuilderTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/SelectBuilderTests.cs
@@ -391,6 +391,29 @@ public class SelectBuilderTests
         sut.ParameterNames.Should().HaveCount(0);
     }
 
+    [Fact]
+    public void Select_BuildsSqlWithMultipleInnerJoins_ReturnsFluentSqlBuilder()
+    {
+        // Arrange
+        var expectedSql = "SELECT *" +
+            $"{Environment.NewLine}FROM Table1" +
+            $"{Environment.NewLine}INNER JOIN Table2 ON Table1.Id = Table2.Id" +
+            $"{Environment.NewLine}INNER JOIN Table3 ON Table2.Id = Table3.Id" +
+            $"{Environment.NewLine}INNER JOIN Table4 ON Table3.Id = Table4.Id";
+
+        // Act
+        var sut = SimpleBuilder.CreateFluent()
+                    .Select($"*")
+                    .From($"Table1")
+                    .InnerJoin($"Table2 ON Table1.Id = Table2.Id")
+                    .InnerJoin($"Table3 ON Table2.Id = Table3.Id")
+                    .InnerJoin($"Table4 ON Table3.Id = Table4.Id");
+
+        // Assert
+        sut.Sql.Should().Be(expectedSql);
+        sut.ParameterNames.Should().HaveCount(0);
+    }
+
     [Theory]
     [AutoData]
     public void Select_BuildsSqlWithInnerFormattableString_ReturnsFluentSqlBuilder(int id, string type)


### PR DESCRIPTION
This change adds a new test method to demonstrate multiple InnerJoin operations in the SelectBuilderTests class. The test showcases how to chain multiple InnerJoin calls and verifies the resulting SQL query. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    