### PR TITLE
Remove targeting .net462 from projects

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,10 +66,11 @@ jobs:
       # - name: DocFx Build
       #   run: docfx build docfx.json
             
-      # - name: Setup Mono
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y mono-complete     
+      - name: Setup Mono
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
+          mono --version    
       # - name: Verify Mono installation
       #   run: mono --version    
       

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,31 +55,33 @@ jobs:
             9.x
             8.x
             
-      - name: Install DocFx
-        run: dotnet tool update -g docfx --version ${{ env.docfx_version }}
-      - name: Generate Xrefmap
-        run: _scripts/generate-xrefmap.sh ${{ env.siteSubpath }}
-      - name: Set Google Analytics Id
-        run: jq --arg gaId "${{ vars.GA_TAG_ID }}" '.build.globalMetadata._googleAnalyticsTagId = $gaId' docfx.json > temp.json && mv temp.json docfx.json
-      - name: Generate Metadata
-        run: _scripts/generate-metadata.sh
-      - name: DocFx Build
-        run: docfx build docfx.json
+      # - name: Install DocFx
+      #   run: dotnet tool update -g docfx --version ${{ env.docfx_version }}
+      # - name: Generate Xrefmap
+      #   run: _scripts/generate-xrefmap.sh ${{ env.siteSubpath }}
+      # - name: Set Google Analytics Id
+      #   run: jq --arg gaId "${{ vars.GA_TAG_ID }}" '.build.globalMetadata._googleAnalyticsTagId = $gaId' docfx.json > temp.json && mv temp.json docfx.json
+      # - name: Generate Metadata
+      #   run: _scripts/generate-metadata.sh
+      # - name: DocFx Build
+      #   run: docfx build docfx.json
             
       # - name: Setup Mono
       #   run: |
       #     sudo apt-get update
       #     sudo apt-get install -y mono-complete     
       # - name: Verify Mono installation
-      #   run: mono --version            
-      # - name: Restore dependencies
-      #   run: dotnet restore
-      # - name: Build solution
-      #   run: dotnet build --no-restore -c $configuration
-      # - name: Run unit tests
-      #   run: dotnet test --no-build -c $configuration --collect:"XPlat Code Coverage" --filter "FullyQualifiedName~UnitTests" --results-directory ${{ env.coverageReportPath }} -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]Dapper.SimpleSqlBuilder.UnitTestHelpers*"
-      # - name: Run integration tests
-      #   run: dotnet test --no-build -c $configuration --filter "FullyQualifiedName~IntegrationTests"
+      #   run: mono --version    
+      
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build solution
+        run: dotnet build --no-restore -c $configuration
+      - name: Run unit tests
+        run: dotnet test --no-build -c $configuration --collect:"XPlat Code Coverage" --filter "FullyQualifiedName~UnitTests" --results-directory ${{ env.coverageReportPath }} -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]Dapper.SimpleSqlBuilder.UnitTestHelpers*"
+      - name: Run integration tests
+        run: dotnet test --no-build -c $configuration --filter "FullyQualifiedName~IntegrationTests"
+      
       # - name: Install dotnet-coverage
       #   run: dotnet tool install --global dotnet-coverage
       # - name: Merge coverage reports

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        # working-directory: src
-        working-directory: docs/github-pages
+        working-directory: src
+        # working-directory: docs/github-pages
     env:
       coverageReportPath: ${{ github.workspace }}/coverage-reports/
       mergedCoverageReportFileName: merged-coverage.xml

--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/README.md
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/README.md
@@ -8,7 +8,7 @@ The benchmark was done with the [BenchmarkDotNet](https://github.com/dotnet/Benc
 To run the benchmark you will need to ensure you have the **corresponding SDKs for the frameworks** installed, then you can execute the command below in the benchmark project directory.
 
 ```cli
-dotnet run -c release -f net9.0 -- --filter * --runtimes net9.0 net462
+dotnet run -c release -f net9.0 -- --filter * --runtimes net9.0
 ```
 
 You can also run the benchmark only for a specific runtime by specifying the runtime in the `--runtimes` argument.

--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
         <NoWarn>IDE0005</NoWarn>
     </PropertyGroup>
 

--- a/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
+++ b/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <Description>A simple and performant SQL builder for Dapper, using string interpolation and a fluent API to build safe, static, and dynamic SQL queries.</Description>
         <RootNamespace>Dapper.SimpleSqlBuilder.StrongName</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.StrongName</AssemblyName>
@@ -11,13 +11,9 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <Using Remove="System.Net.Http"></Using>
-    </ItemGroup>
-
     <ItemGroup>
       <PackageReference Include="Dapper.StrongName" />
-      <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'"/>
+      <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
+++ b/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <Description>A simple and performant SQL builder for Dapper, using string interpolation and a fluent API to build safe, static, and dynamic SQL queries.</Description>
         <RootNamespace>Dapper.SimpleSqlBuilder</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder</AssemblyName>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -51,7 +51,7 @@
         <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     </ItemGroup>
     <Choose>
-        <When Condition="'$(TargetFramework)' == 'net462'">
+        <When Condition="'$(TargetFramework)' == 'net48'">
             <ItemGroup Label="IntegrationTestPackagesNET462">
                 <PackageVersion Include="Npgsql" Version="8.0.6" />
                 <PackageVersion Include="Respawn" Version="4.0.0" />

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -16,7 +16,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition="'$(TargetFramework)' == 'net462'" />
+        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition="'$(TargetFramework)' == 'net48'" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlTestsFixture.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlTestsFixture.cs
@@ -3,7 +3,7 @@ using Dapper.SimpleSqlBuilder.IntegrationTests.Models;
 using Respawn;
 using Testcontainers.MsSql;
 
-#if NET462
+#if NETFRAMEWORK
 
 using System.Data.SqlClient;
 
@@ -19,7 +19,7 @@ public class MSSqlTestsFixture : IAsyncLifetime
 
     private DbConnection dbConnection = null!;
 
-#if NET462
+#if NETFRAMEWORK
     private Checkpoint respawner = null!;
 #else
     private Respawner respawner = null!;
@@ -54,7 +54,7 @@ public class MSSqlTestsFixture : IAsyncLifetime
 
     public async Task ResetDatabaseAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         await respawner.Reset(dbConnection);
 #else
         await respawner.ResetAsync(dbConnection);
@@ -124,7 +124,7 @@ public class MSSqlTestsFixture : IAsyncLifetime
 
     private Task InitialiseRespawnerAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         respawner = new Checkpoint
         {
             SchemasToInclude = ["dbo"],

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTestsFixture.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTestsFixture.cs
@@ -12,7 +12,7 @@ public class MySqlTestsFixture : IAsyncLifetime
 
     private DbConnection dbConnection = null!;
 
-#if NET462
+#if NETFRAMEWORK
     private Checkpoint respawner = null!;
 #else
     private Respawner respawner = null!;
@@ -48,7 +48,7 @@ public class MySqlTestsFixture : IAsyncLifetime
 
     public async Task ResetDatabaseAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         await respawner.Reset(dbConnection);
 #else
         await respawner.ResetAsync(dbConnection);
@@ -115,7 +115,7 @@ public class MySqlTestsFixture : IAsyncLifetime
 
     private Task InitialiseRespawnerAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         respawner = new Checkpoint
         {
             DbAdapter = DbAdapter.MySql,

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlTestsFixture.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlTestsFixture.cs
@@ -12,7 +12,7 @@ public class PostgreSqlTestsFixture : IAsyncLifetime
 
     private DbConnection dbConnection = null!;
 
-#if NET462
+#if NETFRAMEWORK
     private Checkpoint respawner = null!;
 #else
     private Respawner respawner = null!;
@@ -48,7 +48,7 @@ public class PostgreSqlTestsFixture : IAsyncLifetime
 
     public async Task ResetDatabaseAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         await respawner.Reset(dbConnection);
 #else
         await respawner.ResetAsync(dbConnection);
@@ -119,7 +119,7 @@ public class PostgreSqlTestsFixture : IAsyncLifetime
 
     private Task InitialiseRespawnerAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         respawner = new Checkpoint
         {
             SchemasToInclude = ["public"],

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
@@ -14,10 +14,10 @@
     
     <ItemGroup>
         <PackageReference Include="MySqlConnector" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)' != 'net462'" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)' != 'net48'" />
         <PackageReference Include="Npgsql" />
         <PackageReference Include="Respawn" />
-        <PackageReference Include="System.Data.SqlClient" Condition="'$(TargetFramework)' == 'net462'" />
+        <PackageReference Include="System.Data.SqlClient" Condition="'$(TargetFramework)' == 'net48'" />
         <PackageReference Include="TestContainers.MsSql" />
         <PackageReference Include="TestContainers.MySql" />
         <PackageReference Include="TestContainers.PostgreSql" />

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
         <RootNamespace>Dapper.SimpleSqlBuilder.IntegrationTests</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.IntegrationTests</AssemblyName>
         <!--

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/SimpleSqlBuilder.UnitTestHelpers.csproj
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/SimpleSqlBuilder.UnitTestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
         <IsUnitTestProject>true</IsUnitTestProject>
         <RootNamespace>Dapper.SimpleSqlBuilder.UnitTestHelpers</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.UnitTestHelpers</AssemblyName>

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/SimpleSqlBuilder.UnitTests.csproj
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/SimpleSqlBuilder.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
         <IsUnitTestProject>true</IsUnitTestProject>
         <RootNamespace>Dapper.SimpleSqlBuilder.UnitTests</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.UnitTests</AssemblyName>


### PR DESCRIPTION
Update target frameworks in various project files to remove `net462` and replace it with `net48` where applicable.

* **Benchmark Project**
  - Change `net462` to `net48` in `src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj`.
  - Update `src/Benchmark/SimpleSqlBuilder.BenchMark/README.md` to remove references to `net462`.

* **Builder Projects**
  - Remove `net462` from `TargetFrameworks` in `src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj`.
  - Remove `net462` from `TargetFrameworks` in `src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj`.

* **Integration Tests**
  - Change `net462` to `net48` in `src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj`.

* **Unit Tests**
  - Change `net462` to `net48` in `src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/SimpleSqlBuilder.UnitTestHelpers.csproj`.
  - Change `net462` to `net48` in `src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/SimpleSqlBuilder.UnitTests.csproj`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mishael-o/Dapper.SimpleSqlBuilder/pull/106?shareId=e0cb1a26-0450-442b-b9d3-745dea3b62e7).