### PR TITLE
Dropped `net462` target. However, the library still targets `netstandard2.0` which supports `net462` to `net481`.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build solution
         run: dotnet build --no-restore -c $configuration
       - name: Run unit tests
-        run: dotnet test --no-build -c $configuration --collect:"XPlat Code Coverage" --filter "FullyQualifiedName~UnitTests" --results-directory ${{ env.coverageReportPath }} -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]Dapper.SimpleSqlBuilder.UnitTestHelpers*"
+        run: dotnet test --no-build -c $configuration --collect:"XPlat Code Coverage;Format=cobertura" --filter "FullyQualifiedName~UnitTests" --results-directory ${{ env.coverageReportPath }} -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]Dapper.SimpleSqlBuilder.UnitTestHelpers*"
       - name: Run integration tests
         run: dotnet test --no-build -c $configuration --filter "FullyQualifiedName~IntegrationTests"
       - name: Install dotnet-coverage

--- a/docs/github-pages/docfx-xref.json
+++ b/docs/github-pages/docfx-xref.json
@@ -11,7 +11,7 @@
       "outputFormat": "mref",
       "filter": "filters/filterConfig.yml",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net9.0"
       }
     },
     {
@@ -39,7 +39,7 @@
       "outputFormat": "mref",
       "filter": "filters/filterConfig.yml",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net9.0"
       }
     }
   ],

--- a/docs/github-pages/docfx.json
+++ b/docs/github-pages/docfx.json
@@ -11,7 +11,7 @@
       "outputFormat": "apiPage",
       "filter": "filters/filterConfig.yml",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net9.0"
       }
     },
     {
@@ -39,7 +39,7 @@
       "outputFormat": "apiPage",
       "filter": "filters/filterConfig.yml",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net9.0"
       }
     }
   ],

--- a/docs/github-pages/docs/miscellaneous/performance.md
+++ b/docs/github-pages/docs/miscellaneous/performance.md
@@ -16,33 +16,39 @@ Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   Job-AYCPZN : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
   Job-FCIXJG : .NET Framework 4.8.1 (4.8.9290.0), X64 RyuJIT VectorSize=256
 
+Legends:
+  Categories  : All categories of the corresponded method, class, and assembly
+  Mean        : Arithmetic mean of all measurements
+  Allocated   : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  1 μs        : 1 Microsecond (0.000001 sec)
+
 ```
 
-|                             Method |              Runtime |   Categories |      Mean | Allocated |
-|----------------------------------- |--------------------- |------------- |----------:|----------:|
-|                SqlBuilder (Dapper) |             .NET 9.0 | Simple query |  1.641 μs |   2.92 KB |
-|                            Builder |             .NET 9.0 | Simple query |  1.223 μs |   4.42 KB |
-|                      FluentBuilder |             .NET 9.0 | Simple query |  1.435 μs |    4.5 KB |
-|         Builder (Reuse parameters) |             .NET 9.0 | Simple query |  1.900 μs |    4.7 KB |
-|   FluentBuilder (Reuse parameters) |             .NET 9.0 | Simple query |  2.108 μs |   4.77 KB |
-|                                    |                      |              |           |           |
-|                SqlBuilder (Dapper) | .NET Framework 4.6.2 | Simple query |  3.448 μs |   3.43 KB |
-|                            Builder | .NET Framework 4.6.2 | Simple query |  4.031 μs |   4.69 KB |
-|                      FluentBuilder | .NET Framework 4.6.2 | Simple query |  4.698 μs |    5.2 KB |
-|         Builder (Reuse parameters) | .NET Framework 4.6.2 | Simple query |  4.985 μs |   5.27 KB |
-|   FluentBuilder (Reuse parameters) | .NET Framework 4.6.2 | Simple query |  5.805 μs |   5.77 KB |
-|                                    |                      |              |           |           |
-|                                    |                      |              |           |           |
-|                SqlBuilder (Dapper) |             .NET 9.0 |  Large query | 27.723 μs |  42.19 KB |
-|                            Builder |             .NET 9.0 |  Large query | 16.502 μs |  48.78 KB |
-|                      FluentBuilder |             .NET 9.0 |  Large query | 19.042 μs |  48.62 KB |
-|         Builder (Reuse parameters) |             .NET 9.0 |  Large query | 13.741 μs |  29.34 KB |
-|   FluentBuilder (Reuse parameters) |             .NET 9.0 |  Large query | 15.446 μs |  29.18 KB |
-|                                    |                      |              |           |           |
-|                SqlBuilder (Dapper) | .NET Framework 4.6.2 |  Large query | 47.106 μs |   53.1 KB |
-|                            Builder | .NET Framework 4.6.2 |  Large query | 56.699 μs |  62.15 KB |
-|                      FluentBuilder | .NET Framework 4.6.2 |  Large query | 68.462 μs |  68.61 KB |
-|         Builder (Reuse parameters) | .NET Framework 4.6.2 |  Large query | 43.441 μs |  37.42 KB |
-|   FluentBuilder (Reuse parameters) | .NET Framework 4.6.2 |  Large query | 53.723 μs |  43.87 KB |
+| Method                             | Runtime            | Categories   | Mean      | Allocated |
+|----------------------------------- |------------------- |------------- |----------:|----------:|
+| SqlBuilder (Dapper)                | .NET 9.0           | Simple query |  1.614 us |   2.93 KB |
+| Builder                            | .NET 9.0           | Simple query |  1.222 us |    4.5 KB |
+| FluentBuilder                      | .NET 9.0           | Simple query |  1.390 us |   4.59 KB |
+| Builder (Reuse parameters)         | .NET 9.0           | Simple query |  1.842 us |   4.77 KB |
+| FluentBuilder (Reuse parameters)   | .NET 9.0           | Simple query |  1.987 us |   4.86 KB |
+|                                    |                    |              |           |           |
+| SqlBuilder (Dapper)                | .NET Framework 4.8 | Simple query |  3.485 us |   3.44 KB |
+| Builder                            | .NET Framework 4.8 | Simple query |  4.378 us |   5.32 KB |
+| FluentBuilder                      | .NET Framework 4.8 | Simple query |  4.830 us |   5.25 KB |
+| Builder (Reuse parameters)         | .NET Framework 4.8 | Simple query |  5.134 us |   5.89 KB |
+| FluentBuilder (Reuse parameters)   | .NET Framework 4.8 | Simple query |  5.799 us |   5.82 KB |
+|                                    |                    |              |           |           |
+|                                    |                    |              |           |           |
+| SqlBuilder (Dapper)                | .NET 9.0           | Large query  | 27.432 μs |  42.42 KB |
+| Builder                            | .NET 9.0           | Large query  | 16.493 μs |  49.05 KB |
+| FluentBuilder                      | .NET 9.0           | Large query  | 18.964 μs |  48.89 KB |
+| Builder (Reuse parameters)         | .NET 9.0           | Large query  | 12.842 μs |  29.41 KB |
+| FluentBuilder (Reuse parameters)   | .NET 9.0           | Large query  | 14.713 μs |   29.3 KB |
+|                                    |                    |              |           |           |
+| SqlBuilder (Dapper)                | .NET Framework 4.8 | Large query  | 46.692 μs |  53.32 KB |
+| Builder                            | .NET Framework 4.8 | Large query  | 58.544 μs |  61.96 KB |
+| FluentBuilder                      | .NET Framework 4.8 | Large query  | 68.833 μs |  68.43 KB |
+| Builder (Reuse parameters)         | .NET Framework 4.8 | Large query  | 44.878 μs |  37.13 KB |
+| FluentBuilder (Reuse parameters)   | .NET Framework 4.8 | Large query  | 55.460 μs |  43.63 KB |
 
 Refer to the [benchmark project](https://github.com/mishael-o/Dapper.SimpleSqlBuilder/tree/main/src/Benchmark/SimpleSqlBuilder.BenchMark) for more information.

--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/Benchmarks/Product.cs
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/Benchmarks/Product.cs
@@ -3,10 +3,9 @@
 internal sealed record Product
 {
     public Guid Id { get; set; }
-    public int TypeId { get; set; }
-    public string Description { get; set; } = default!;
+    public string ProductCode { get; set; } = default!;
     public double RecommendedPrice { get; set; }
     public decimal SellingPrice { get; set; }
-    public bool IsActive { get; set; }
-    public DateTimeOffset CreateDate { get; set; }
+    public bool IsActive { get; set; } = true;
+    public DateTimeOffset CreateDate { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/Benchmarks/SimpleSqlBuilderBenchmark.cs
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/Benchmarks/SimpleSqlBuilderBenchmark.cs
@@ -1,5 +1,4 @@
-﻿using AutoFixture;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Dapper;
 using Dapper.SimpleSqlBuilder;
@@ -12,29 +11,39 @@ namespace SimpleSqlBuilder.BenchMark.Benchmarks;
 public class SimpleSqlBuilderBenchmark
 {
     private const int WhereOperationCount = 20;
-    private static readonly int[] TypeIds = [1, 2, 3, 4, 5];
 
     private Product product = default!;
+    private int[] typeIds = default!;
 
     [GlobalSetup]
     public void GlobalSetUp()
-        => product = new Fixture().Create<Product>();
+    {
+        product = new()
+        {
+            Id = Guid.NewGuid(),
+            ProductCode = "Product Code",
+            RecommendedPrice = 100.00,
+            SellingPrice = 99.99m
+        };
+
+        typeIds = [.. Enumerable.Range(1, 10)];
+    }
 
     [Benchmark(Description = "SqlBuilder (Dapper)", Baseline = true)]
     [BenchmarkCategory("Simple query")]
     public string SqlBuilder()
     {
         const string sql = $"""
-            SELECT x.*, (SELECT TypeSource FROM ProductType WHERE Id = @{nameof(Product.TypeId)} OR Description = @{nameof(Product.Description)})
+            SELECT x.*, (SELECT Description FROM ProductDetail WHERE Id = @{nameof(Product.Id)} OR ProductCode = @{nameof(Product.ProductCode)})
             FROM Product x
             /**where**/
             """;
 
         var sqlBuilder = new SqlBuilder()
             .Where($"Id = @{nameof(Product.Id)}", new { product.Id })
-            .Where($"TypeId IN @{nameof(TypeIds)}", TypeIds)
+            .Where($"ProductCode = @{nameof(Product.ProductCode)}", new { product.ProductCode })
+            .Where($"TypeId IN @{nameof(typeIds)}", new { typeIds })
             .Where($"RecommendedPrice = @{nameof(Product.RecommendedPrice)}", new { product.RecommendedPrice })
-            .Where($"Description = @{nameof(Product.Description)}", new { product.Description })
             .Where($"SellingPrice = @{nameof(Product.SellingPrice)}", new { product.SellingPrice })
             .Where($"IsActive = @{nameof(Product.IsActive)}", new { product.IsActive })
             .Where($"CreateDate = @{nameof(Product.CreateDate)}", new { product.CreateDate });
@@ -49,11 +58,11 @@ public class SimpleSqlBuilderBenchmark
     {
         var builder = SimpleBuilder.Create(
             $"""
-               SELECT x.*, (SELECT TypeSource FROM ProductType WHERE Id = {product.TypeId} OR Description = {product.Description})
+               SELECT x.*, (SELECT Description FROM ProductDetail WHERE Id = {product.Id} OR ProductCode = {product.ProductCode})
                FROM Product x
                WHERE Id = {product.Id}
-               AND TypeId IN {TypeIds}
-               AND Description = {product.Description}
+               AND ProductCode = {product.ProductCode}
+               AND TypeId IN {typeIds}
                AND RecommendedPrice = {product.RecommendedPrice}
                AND SellingPrice = {product.SellingPrice}
                AND IsActive = {product.IsActive}
@@ -68,11 +77,11 @@ public class SimpleSqlBuilderBenchmark
     public string SimpleSqlFluentBuilder()
     {
         var builder = SimpleBuilder.CreateFluent()
-            .Select($"x.*, (SELECT TypeSource FROM ProductType WHERE Id = {product.TypeId} OR Description = {product.Description})")
+            .Select($"x.*, (SELECT Description FROM ProductDetail WHERE Id = {product.Id} OR ProductCode = {product.ProductCode})")
             .From($"Product x")
             .Where($"Id = {product.Id}")
-            .Where($"TypeId IN {TypeIds}")
-            .Where($"Description = {product.Description}")
+            .Where($"ProductCode = {product.ProductCode}")
+            .Where($"TypeId IN {typeIds}")
             .Where($"RecommendedPrice = {product.RecommendedPrice}")
             .Where($"SellingPrice = {product.SellingPrice}")
             .Where($"IsActive = {product.IsActive}")
@@ -85,13 +94,15 @@ public class SimpleSqlBuilderBenchmark
     [BenchmarkCategory("Simple query")]
     public string SimpleSqlBuilderReuseParameters()
     {
+        ////AND Name = { product.Name }
+
         var builder = SimpleBuilder.Create(reuseParameters: true)
             .AppendIntact($"""
-               SELECT x.*, (SELECT TypeSource FROM ProductType WHERE Id = {product.TypeId} OR Description = {product.Description})
+               SELECT x.*, (SELECT Description FROM ProductDetail WHERE Id = {product.Id} OR ProductCode = {product.ProductCode})
                FROM Product x
                WHERE Id = {product.Id}
-               AND TypeId IN {TypeIds}
-               AND Description = {product.Description}
+               AND ProductCode = {product.ProductCode}
+               AND TypeId IN {typeIds}
                AND RecommendedPrice = {product.RecommendedPrice}
                AND SellingPrice = {product.SellingPrice}
                AND IsActive = {product.IsActive}
@@ -106,11 +117,11 @@ public class SimpleSqlBuilderBenchmark
     public string SimpleSqlFluentBuilderReuseParameters()
     {
         var builder = SimpleBuilder.CreateFluent(reuseParameters: true)
-            .Select($"x.*, (SELECT TypeSource FROM ProductType WHERE Id = {product.TypeId} OR Description = {product.Description})")
+            .Select($"x.*, (SELECT Description FROM ProductDetail WHERE Id = {product.Id} OR ProductCode = {product.ProductCode})")
             .From($"Product x")
             .Where($"Id = {product.Id}")
-            .Where($"TypeId IN {TypeIds}")
-            .Where($"Description = {product.Description}")
+            .Where($"ProductCode = {product.ProductCode}")
+            .Where($"TypeId IN {typeIds}")
             .Where($"RecommendedPrice = {product.RecommendedPrice}")
             .Where($"SellingPrice = {product.SellingPrice}")
             .Where($"IsActive = {product.IsActive}")
@@ -124,7 +135,7 @@ public class SimpleSqlBuilderBenchmark
     public string SqlBuilderLarge()
     {
         const string sql = $"""
-            SELECT x.*, (SELECT TypeSource FROM ProductType WHERE Id = @{nameof(Product.TypeId)} OR Description = @{nameof(Product.Description)})
+            SELECT x.*, (SELECT Description FROM ProductDetail WHERE Id = @{nameof(Product.Id)} OR ProductCode = @{nameof(Product.ProductCode)})
             FROM Product x
             /**where**/
             """;
@@ -136,8 +147,8 @@ public class SimpleSqlBuilderBenchmark
         {
             sqlBuilder
                 .Where($"Id = @{nameof(Product.Id)}", new { product.Id })
-                .Where($"TypeId IN @{nameof(TypeIds)}", TypeIds)
-                .Where($"Description = @{nameof(Product.Description)}", new { product.Description })
+                .Where($"ProductCode = @{nameof(Product.ProductCode)}", new { product.ProductCode })
+                .Where($"TypeId IN @{nameof(typeIds)}", new { typeIds })
                 .Where($"RecommendedPrice = @{nameof(Product.RecommendedPrice)}", new { product.RecommendedPrice })
                 .Where($"SellingPrice = @{nameof(Product.SellingPrice)}", new { product.SellingPrice })
                 .Where($"IsActive = @{nameof(Product.IsActive)}", new { product.IsActive })
@@ -154,7 +165,7 @@ public class SimpleSqlBuilderBenchmark
     {
         var builder = SimpleBuilder.Create(
             $"""
-               SELECT x.*, (SELECT TypeSource FROM ProductType WHERE Id = {product.TypeId} OR Description = {product.Description})
+               SELECT x.*, (SELECT Description FROM ProductDetail WHERE Id = {product.Id} OR ProductCode = {product.ProductCode})
                FROM Product x
                WHERE 1 = 1
                """);
@@ -164,8 +175,8 @@ public class SimpleSqlBuilderBenchmark
         {
             builder.Append($"""
                AND Id = {product.Id}
-               AND TypeId IN {TypeIds}
-               AND Description = {product.Description}
+               AND ProductCode = {product.ProductCode}
+               AND TypeId IN {typeIds}
                AND RecommendedPrice = {product.RecommendedPrice}
                AND SellingPrice = {product.SellingPrice}
                AND IsActive = {product.IsActive}
@@ -181,7 +192,7 @@ public class SimpleSqlBuilderBenchmark
     public string SimpleSqlFluentBuilderLarge()
     {
         var builder = SimpleBuilder.CreateFluent()
-            .Select($"x.*, (SELECT TypeSource FROM ProductType WHERE Id = {product.TypeId} OR Description = {product.Description})")
+            .Select($"x.*, (SELECT Description FROM ProductDetail WHERE Id = {product.Id} OR ProductCode = {product.ProductCode})")
             .From($"Product x");
 
         // Simulating large query
@@ -189,8 +200,8 @@ public class SimpleSqlBuilderBenchmark
         {
             builder
                 .Where($"Id = {product.Id}")
-                .Where($"TypeId IN {TypeIds}")
-                .Where($"Description = {product.Description}")
+                .Where($"ProductCode = {product.ProductCode}")
+                .Where($"TypeId IN {typeIds}")
                 .Where($"RecommendedPrice = {product.RecommendedPrice}")
                 .Where($"SellingPrice = {product.SellingPrice}")
                 .Where($"IsActive = {product.IsActive}")
@@ -206,7 +217,7 @@ public class SimpleSqlBuilderBenchmark
     {
         var builder = SimpleBuilder.Create(reuseParameters: true)
             .AppendIntact($"""
-               SELECT x.*, (SELECT TypeSource FROM ProductType WHERE Id = {product.TypeId} OR Description = {product.Description})
+               SELECT x.*, (SELECT Description FROM ProductDetail WHERE Id = {product.Id} OR ProductCode = {product.ProductCode})
                FROM Product x
                WHERE 1 = 1
                """);
@@ -216,8 +227,8 @@ public class SimpleSqlBuilderBenchmark
         {
             builder.Append($"""
                AND Id = {product.Id}
-               AND TypeId IN {TypeIds}
-               AND Description = {product.Description}
+               AND ProductCode = {product.ProductCode}
+               AND TypeId IN {typeIds}
                AND RecommendedPrice = {product.RecommendedPrice}
                AND SellingPrice = {product.SellingPrice}
                AND IsActive = {product.IsActive}
@@ -233,7 +244,7 @@ public class SimpleSqlBuilderBenchmark
     public string SimpleSqlFluentBuilderLargeReuseParameters()
     {
         var builder = SimpleBuilder.CreateFluent(reuseParameters: true)
-            .Select($"x.*, (SELECT TypeSource FROM ProductType WHERE Id = {product.TypeId} OR Description = {product.Description})")
+            .Select($"x.*, (SELECT Description FROM ProductDetail WHERE Id = {product.Id} OR ProductCode = {product.ProductCode})")
             .From($"Product x");
 
         // Simulating large query
@@ -241,8 +252,8 @@ public class SimpleSqlBuilderBenchmark
         {
             builder
                 .Where($"Id = {product.Id}")
-                .Where($"TypeId IN {TypeIds}")
-                .Where($"Description = {product.Description}")
+                .Where($"ProductCode =  {product.ProductCode}")
+                .Where($"TypeId IN {typeIds}")
                 .Where($"RecommendedPrice = {product.RecommendedPrice}")
                 .Where($"SellingPrice = {product.SellingPrice}")
                 .Where($"IsActive = {product.IsActive}")

--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/README.md
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/README.md
@@ -8,13 +8,13 @@ The benchmark was done with the [BenchmarkDotNet](https://github.com/dotnet/Benc
 To run the benchmark you will need to ensure you have the **corresponding SDKs for the frameworks** installed, then you can execute the command below in the benchmark project directory.
 
 ```cli
-dotnet run -c release -f net9.0 -- --filter * --runtimes net9.0 net462
+dotnet run -c release -f net9.0 --runtimes net9.0 net48 -- --filter '*'
 ```
 
-You can also run the benchmark only for a specific runtime by specifying the runtime in the `--runtimes` argument.
+You can also run the benchmark only for a specific framework.
 
 ```cli
-dotnet run -c release -f net9.0 -- --filter * --runtimes net9.0
+dotnet run -c release -f net9.0 --filter '*'
 ```
 
 ## Result

--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/README.md
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/README.md
@@ -43,29 +43,29 @@ Legends:
 
 ```
 
-|                             Method |              Runtime |   Categories |      Mean |     Error |    StdDev | Ratio | RatioSD |    Gen0 |   Gen1 | Allocated | Alloc Ratio |
-|----------------------------------- |--------------------- |------------- |----------:|----------:|----------:|------:|--------:|--------:|-------:|----------:|------------:|
-|                SqlBuilder (Dapper) |             .NET 9.0 | Simple query |  1.641 μs | 0.0318 μs | 0.0298 μs |  1.00 |    0.00 |  0.6351 | 0.0019 |   2.92 KB |        1.00 |
-|                            Builder |             .NET 9.0 | Simple query |  1.223 μs | 0.0240 μs | 0.0312 μs |  0.75 |    0.02 |  0.9613 | 0.0114 |   4.42 KB |        1.51 |
-|                      FluentBuilder |             .NET 9.0 | Simple query |  1.435 μs | 0.0253 μs | 0.0224 μs |  0.87 |    0.02 |  0.9785 | 0.0114 |    4.5 KB |        1.54 |
-|         Builder (Reuse parameters) |             .NET 9.0 | Simple query |  1.900 μs | 0.0359 μs | 0.0369 μs |  1.16 |    0.03 |  1.0204 | 0.0134 |    4.7 KB |        1.61 |
-|   FluentBuilder (Reuse parameters) |             .NET 9.0 | Simple query |  2.108 μs | 0.0409 μs | 0.0546 μs |  1.28 |    0.05 |  1.0376 | 0.0153 |   4.77 KB |        1.63 |
-|                                    |                      |              |           |           |           |       |         |         |        |           |             |
-|                SqlBuilder (Dapper) | .NET Framework 4.6.2 | Simple query |  3.448 μs | 0.0606 μs | 0.0567 μs |  2.10 |    0.04 |  0.7439 | 0.0038 |   3.43 KB |        1.17 |
-|                            Builder | .NET Framework 4.6.2 | Simple query |  4.031 μs | 0.0777 μs | 0.0832 μs |  2.46 |    0.06 |  1.0147 | 0.0076 |   4.69 KB |        1.61 |
-|                      FluentBuilder | .NET Framework 4.6.2 | Simple query |  4.698 μs | 0.0932 μs | 0.0915 μs |  2.86 |    0.08 |  1.1215 | 0.0076 |    5.2 KB |        1.78 |
-|         Builder (Reuse parameters) | .NET Framework 4.6.2 | Simple query |  4.985 μs | 0.0812 μs | 0.0760 μs |  3.04 |    0.08 |  1.1368 | 0.0076 |   5.27 KB |        1.80 |
-|   FluentBuilder (Reuse parameters) | .NET Framework 4.6.2 | Simple query |  5.805 μs | 0.1126 μs | 0.1156 μs |  3.54 |    0.09 |  1.2512 | 0.0153 |   5.77 KB |        1.98 |
-|                                    |                      |              |           |           |           |       |         |         |        |           |             |
-|                                    |                      |              |           |           |           |       |         |         |        |           |             |
-|                SqlBuilder (Dapper) |             .NET 9.0 |  Large query | 27.723 μs | 0.3809 μs | 0.3563 μs |  1.00 |    0.00 |  9.1553 | 0.9155 |  42.19 KB |        1.00 |
-|                            Builder |             .NET 9.0 |  Large query | 16.502 μs | 0.3285 μs | 0.5016 μs |  0.60 |    0.02 | 10.5896 | 1.2512 |  48.78 KB |        1.16 |
-|                      FluentBuilder |             .NET 9.0 |  Large query | 19.042 μs | 0.3493 μs | 0.3268 μs |  0.69 |    0.02 | 10.5591 | 1.3123 |  48.62 KB |        1.15 |
-|         Builder (Reuse parameters) |             .NET 9.0 |  Large query | 13.741 μs | 0.2241 μs | 0.1871 μs |  0.50 |    0.01 |  6.3782 | 0.2441 |  29.34 KB |        0.70 |
-|   FluentBuilder (Reuse parameters) |             .NET 9.0 |  Large query | 15.446 μs | 0.2821 μs | 0.2501 μs |  0.56 |    0.01 |  6.3477 | 0.2441 |  29.18 KB |        0.69 |
-|                                    |                      |              |           |           |           |       |         |         |        |           |             |
-|                SqlBuilder (Dapper) | .NET Framework 4.6.2 |  Large query | 47.106 μs | 0.9295 μs | 0.8695 μs |  1.70 |    0.04 | 11.4746 | 0.9155 |   53.1 KB |        1.26 |
-|                            Builder | .NET Framework 4.6.2 |  Large query | 56.699 μs | 0.8183 μs | 0.7254 μs |  2.05 |    0.03 | 13.4277 | 1.6479 |  62.15 KB |        1.47 |
-|                      FluentBuilder | .NET Framework 4.6.2 |  Large query | 68.462 μs | 1.3275 μs | 1.8172 μs |  2.47 |    0.08 | 14.7705 | 1.7090 |  68.61 KB |        1.63 |
-|         Builder (Reuse parameters) | .NET Framework 4.6.2 |  Large query | 43.441 μs | 0.8512 μs | 0.9802 μs |  1.57 |    0.05 |  8.0566 | 0.3052 |  37.42 KB |        0.89 |
-|   FluentBuilder (Reuse parameters) | .NET Framework 4.6.2 |  Large query | 53.723 μs | 0.8383 μs | 0.7841 μs |  1.94 |    0.05 |  9.4604 | 0.3662 |  43.87 KB |        1.04 |
+| Method                             | Runtime            | Categories   | Mean      | Error     | StdDev    | Ratio | RatioSD | Gen0    | Gen1   | Allocated | Alloc Ratio |
+|----------------------------------- |------------------- |------------- |----------:|----------:|----------:|------:|--------:|--------:|-------:|----------:|------------:|
+| SqlBuilder (Dapper)                | .NET 9.0           | Simple query |  1.614 us | 0.0274 us | 0.0229 us |  1.00 |    0.00 |  0.6371 | 0.0038 |   2.93 KB |        1.00 |
+| Builder                            | .NET 9.0           | Simple query |  1.222 us | 0.0164 us | 0.0145 us |  0.76 |    0.02 |  0.9785 | 0.0114 |    4.5 KB |        1.54 |
+| FluentBuilder                      | .NET 9.0           | Simple query |  1.390 us | 0.0185 us | 0.0164 us |  0.86 |    0.02 |  0.9975 | 0.0134 |   4.59 KB |        1.57 |
+| Builder (Reuse parameters)         | .NET 9.0           | Simple query |  1.842 us | 0.0193 us | 0.0171 us |  1.14 |    0.01 |  1.0376 | 0.0153 |   4.77 KB |        1.63 |
+| FluentBuilder (Reuse parameters)   | .NET 9.0           | Simple query |  1.987 us | 0.0386 us | 0.0361 us |  1.23 |    0.03 |  1.0567 | 0.0153 |   4.86 KB |        1.66 |
+|                                    |                    |              |           |           |           |       |         |         |        |           |             |
+| SqlBuilder (Dapper)                | .NET Framework 4.8 | Simple query |  3.485 us | 0.0474 us | 0.0879 us |  2.19 |    0.08 |  0.7439 | 0.0038 |   3.44 KB |        1.17 |
+| Builder                            | .NET Framework 4.8 | Simple query |  4.378 us | 0.0515 us | 0.0456 us |  2.71 |    0.05 |  1.1520 | 0.0076 |   5.32 KB |        1.82 |
+| FluentBuilder                      | .NET Framework 4.8 | Simple query |  4.830 us | 0.0536 us | 0.0502 us |  2.99 |    0.05 |  1.1368 | 0.0076 |   5.25 KB |        1.79 |
+| Builder (Reuse parameters)         | .NET Framework 4.8 | Simple query |  5.134 us | 0.0772 us | 0.0685 us |  3.18 |    0.06 |  1.2741 | 0.0153 |   5.89 KB |        2.01 |
+| FluentBuilder (Reuse parameters)   | .NET Framework 4.8 | Simple query |  5.799 us | 0.0291 us | 0.0243 us |  3.59 |    0.05 |  1.2589 | 0.0153 |   5.82 KB |        1.99 |
+|                                    |                    |              |           |           |           |       |         |         |        |           |             |
+|                                    |                    |              |           |           |           |       |         |         |        |           |             |
+| SqlBuilder (Dapper)                | .NET 9.0           | Large query  | 27.432 μs | 0.1997 μs | 0.1868 μs |  1.00 |    0.00 |  9.2163 | 0.7629 |  42.42 KB |        1.00 |
+| Builder                            | .NET 9.0           | Large query  | 16.493 μs | 0.2553 μs | 0.2264 μs |  0.60 |    0.01 | 10.6506 | 1.1597 |  49.05 KB |        1.16 |
+| FluentBuilder                      | .NET 9.0           | Large query  | 18.964 μs | 0.2916 μs | 0.2728 μs |  0.69 |    0.01 | 10.6201 | 1.3123 |  48.89 KB |        1.15 |
+| Builder (Reuse parameters)         | .NET 9.0           | Large query  | 12.842 μs | 0.1155 μs | 0.0902 μs |  0.47 |    0.01 |  6.3934 | 0.2594 |  29.41 KB |        0.69 |
+| FluentBuilder (Reuse parameters)   | .NET 9.0           | Large query  | 14.713 μs | 0.1177 μs | 0.1044 μs |  0.54 |    0.01 |  6.3629 | 0.2441 |   29.3 KB |        0.69 |
+|                                    |                    |              |           |           |           |       |         |         |        |           |             |
+| SqlBuilder (Dapper)                | .NET Framework 4.8 | Large query  | 46.692 μs | 0.3956 μs | 0.3507 μs |  1.70 |    0.02 | 11.5356 | 1.0986 |  53.32 KB |        1.26 |
+| Builder                            | .NET Framework 4.8 | Large query  | 58.544 μs | 0.3523 μs | 0.3123 μs |  2.14 |    0.02 | 13.4277 | 0.1221 |  61.96 KB |        1.46 |
+| FluentBuilder                      | .NET Framework 4.8 | Large query  | 68.833 μs | 0.7452 μs | 0.6222 μs |  2.51 |    0.03 | 14.7705 | 1.7090 |  68.43 KB |        1.61 |
+| Builder (Reuse parameters)         | .NET Framework 4.8 | Large query  | 44.878 μs | 0.4036 μs | 0.3578 μs |  1.64 |    0.02 |  7.9956 | 0.3052 |  37.13 KB |        0.88 |
+| FluentBuilder (Reuse parameters)   | .NET Framework 4.8 | Large query  | 55.460 μs | 0.4013 μs | 0.3753 μs |  2.02 |    0.02 |  9.4604 | 0.3662 |  43.63 KB |        1.03 |

--- a/src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj
+++ b/src/Benchmark/SimpleSqlBuilder.BenchMark/SimpleSqlBuilder.BenchMark.csproj
@@ -2,12 +2,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
         <NoWarn>IDE0005</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" />
         <PackageReference Include="BenchmarkDotNet" />
         <PackageReference Include="Dapper.SqlBuilder" />
     </ItemGroup>

--- a/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
+++ b/src/Builder/SimpleSqlBuilder.StrongName/SimpleSqlBuilder.StrongName.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <Description>A simple and performant SQL builder for Dapper, using string interpolation and a fluent API to build safe, static, and dynamic SQL queries.</Description>
         <RootNamespace>Dapper.SimpleSqlBuilder.StrongName</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.StrongName</AssemblyName>
@@ -11,13 +11,9 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <Using Remove="System.Net.Http"></Using>
-    </ItemGroup>
-
     <ItemGroup>
       <PackageReference Include="Dapper.StrongName" />
-      <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'"/>
+      <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Builder/SimpleSqlBuilder/Core/SimpleParameterInfo.cs
+++ b/src/Builder/SimpleSqlBuilder/Core/SimpleParameterInfo.cs
@@ -20,16 +20,16 @@ public sealed class SimpleParameterInfo : ISimpleParameterInfo
     /// <param name="precision">The parameter precision.</param>
     /// <param name="scale">The parameter scale.</param>
     public SimpleParameterInfo(object? value, DbType? dbType = null, int? size = null, byte? precision = null, byte? scale = null)
-        : this(null, value, dbType, null, size, precision, scale)
+        : this(null, value, dbType, size, precision, scale)
     {
     }
 
-    internal SimpleParameterInfo(string? name, object? value, DbType? dbType = null, ParameterDirection? direction = null, int? size = null, byte? precision = null, byte? scale = null)
+    internal SimpleParameterInfo(string? name, object? value, DbType? dbType = null, int? size = null, byte? precision = null, byte? scale = null)
     {
         Value = value;
         Name = name;
         DbType = dbType;
-        Direction = direction ?? ParameterDirection.Input;
+        Direction = ParameterDirection.Input;
         Size = size;
         Precision = precision;
         Scale = scale;
@@ -38,10 +38,6 @@ public sealed class SimpleParameterInfo : ISimpleParameterInfo
 
     /// <inheritdoc/>
     public object? Value { get; }
-
-    internal string? Name { get; private set; }
-
-    internal ParameterDirection Direction { get; }
 
     /// <inheritdoc/>
     public DbType? DbType { get; }
@@ -54,6 +50,10 @@ public sealed class SimpleParameterInfo : ISimpleParameterInfo
 
     /// <inheritdoc/>
     public byte? Scale { get; }
+
+    internal string? Name { get; private set; }
+
+    internal ParameterDirection Direction { get; }
 
     internal Type? Type { get; }
 

--- a/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
+++ b/src/Builder/SimpleSqlBuilder/SimpleSqlBuilder.csproj
@@ -1,20 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <Description>A simple and performant SQL builder for Dapper, using string interpolation and a fluent API to build safe, static, and dynamic SQL queries.</Description>
         <RootNamespace>Dapper.SimpleSqlBuilder</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder</AssemblyName>
         <Title>Dapper SimpleSqlBuilder</Title>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <Using Remove="System.Net.Http"></Using>
-    </ItemGroup>
-
     <ItemGroup>
         <PackageReference Include="Dapper" />
-        <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'" />
+        <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,7 +21,7 @@
         <PackageVersion Include="AutoFixture" Version="4.18.1" />
         <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
         <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.3">
+        <PackageVersion Include="coverlet.collector" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageVersion>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,16 +21,22 @@
         <PackageVersion Include="AutoFixture" Version="4.18.1" />
         <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
         <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
         <PackageVersion Include="FluentAssertions" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageVersion Include="Moq" Version="[4.18.4]" />
         <!--For unit test issues on Linux https://github.com/microsoft/vstest/issues/2469-->
-        <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />
+        <!--<PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />-->
         <PackageVersion Include="xunit" Version="2.9.2" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
     </ItemGroup>
     <ItemGroup Label="IntegrationTestPackages">
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
@@ -42,7 +48,7 @@
     </ItemGroup>
     <ItemGroup Label="BenchmarkPackages">
         <PackageVersion Include="Dapper.SqlBuilder" Version="2.0.78" />
-        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     </ItemGroup>
     <!--This is to upgrade any venerable transitive package to the latest one-->
     <ItemGroup Label="TransitivePackages">
@@ -51,8 +57,8 @@
         <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     </ItemGroup>
     <Choose>
-        <When Condition="'$(TargetFramework)' == 'net462'">
-            <ItemGroup Label="IntegrationTestPackagesNET462">
+        <When Condition="'$(TargetFramework)' == 'net48'">
+            <ItemGroup Label="IntegrationTestPackagesNET48">
                 <PackageVersion Include="Npgsql" Version="8.0.6" />
                 <PackageVersion Include="Respawn" Version="4.0.0" />
             </ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -30,8 +30,6 @@
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageVersion Include="Moq" Version="[4.18.4]" />
-        <!--For unit test issues on Linux https://github.com/microsoft/vstest/issues/2469-->
-        <!--<PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />-->
         <PackageVersion Include="xunit" Version="2.9.2" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -10,18 +10,12 @@
     <ItemGroup Label="GlobalTestsItemGroup" Condition="'$(IsTestProject)' == 'true'">
         <PackageReference Include="AutoFixture" />
         <PackageReference Include="AutoFixture.Xunit2" />
-        <PackageReference Include="coverlet.collector">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="coverlet.collector" />
+        <!--<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition="'$(TargetFramework)' == 'net48'" />-->
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition="'$(TargetFramework)' == 'net462'" />
         <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
+        <PackageReference Include="xunit.runner.visualstudio" />
         <Using Include="AutoFixture" />
         <Using Include="AutoFixture.Xunit2" />
         <Using Include="FluentAssertions" />

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -11,7 +11,6 @@
         <PackageReference Include="AutoFixture" />
         <PackageReference Include="AutoFixture.Xunit2" />
         <PackageReference Include="coverlet.collector" />
-        <!--<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition="'$(TargetFramework)' == 'net48'" />-->
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlTestsFixture.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlTestsFixture.cs
@@ -3,7 +3,7 @@ using Dapper.SimpleSqlBuilder.IntegrationTests.Models;
 using Respawn;
 using Testcontainers.MsSql;
 
-#if NET462
+#if NETFRAMEWORK
 
 using System.Data.SqlClient;
 
@@ -19,7 +19,7 @@ public class MSSqlTestsFixture : IAsyncLifetime
 
     private DbConnection dbConnection = null!;
 
-#if NET462
+#if NETFRAMEWORK
     private Checkpoint respawner = null!;
 #else
     private Respawner respawner = null!;
@@ -54,7 +54,7 @@ public class MSSqlTestsFixture : IAsyncLifetime
 
     public async Task ResetDatabaseAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         await respawner.Reset(dbConnection);
 #else
         await respawner.ResetAsync(dbConnection);
@@ -124,7 +124,7 @@ public class MSSqlTestsFixture : IAsyncLifetime
 
     private Task InitialiseRespawnerAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         respawner = new Checkpoint
         {
             SchemasToInclude = ["dbo"],

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTestsFixture.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTestsFixture.cs
@@ -12,7 +12,7 @@ public class MySqlTestsFixture : IAsyncLifetime
 
     private DbConnection dbConnection = null!;
 
-#if NET462
+#if NETFRAMEWORK
     private Checkpoint respawner = null!;
 #else
     private Respawner respawner = null!;
@@ -48,7 +48,7 @@ public class MySqlTestsFixture : IAsyncLifetime
 
     public async Task ResetDatabaseAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         await respawner.Reset(dbConnection);
 #else
         await respawner.ResetAsync(dbConnection);
@@ -115,7 +115,7 @@ public class MySqlTestsFixture : IAsyncLifetime
 
     private Task InitialiseRespawnerAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         respawner = new Checkpoint
         {
             DbAdapter = DbAdapter.MySql,

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlTestsFixture.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlTestsFixture.cs
@@ -12,7 +12,7 @@ public class PostgreSqlTestsFixture : IAsyncLifetime
 
     private DbConnection dbConnection = null!;
 
-#if NET462
+#if NETFRAMEWORK
     private Checkpoint respawner = null!;
 #else
     private Respawner respawner = null!;
@@ -48,7 +48,7 @@ public class PostgreSqlTestsFixture : IAsyncLifetime
 
     public async Task ResetDatabaseAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         await respawner.Reset(dbConnection);
 #else
         await respawner.ResetAsync(dbConnection);
@@ -119,7 +119,7 @@ public class PostgreSqlTestsFixture : IAsyncLifetime
 
     private Task InitialiseRespawnerAsync()
     {
-#if NET462
+#if NETFRAMEWORK
         respawner = new Checkpoint
         {
             SchemasToInclude = ["public"],

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/SimpleSqlBuilder.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
         <RootNamespace>Dapper.SimpleSqlBuilder.IntegrationTests</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.IntegrationTests</AssemblyName>
         <!--
@@ -14,10 +14,10 @@
     
     <ItemGroup>
         <PackageReference Include="MySqlConnector" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)' != 'net462'" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)' != 'net48'" />
         <PackageReference Include="Npgsql" />
         <PackageReference Include="Respawn" />
-        <PackageReference Include="System.Data.SqlClient" Condition="'$(TargetFramework)' == 'net462'" />
+        <PackageReference Include="System.Data.SqlClient" Condition="'$(TargetFramework)' == 'net48'" />
         <PackageReference Include="TestContainers.MsSql" />
         <PackageReference Include="TestContainers.MySql" />
         <PackageReference Include="TestContainers.PostgreSql" />

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/SimpleSqlBuilder.UnitTestHelpers.csproj
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTestHelpers/SimpleSqlBuilder.UnitTestHelpers.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
         <IsUnitTestProject>true</IsUnitTestProject>
         <RootNamespace>Dapper.SimpleSqlBuilder.UnitTestHelpers</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.UnitTestHelpers</AssemblyName>
     </PropertyGroup>
-
+    
 </Project>

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleParameterInfoComparerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleParameterInfoComparerTests.cs
@@ -82,7 +82,6 @@ public class SimpleParameterInfoComparerTests
                 yield return new object[] { new SimpleParameterInfo(values[i].Value, values[i].DbType, size), new SimpleParameterInfo(values[i].Value, values[i].DbType, size) };
                 yield return new object[] { new SimpleParameterInfo(values[i].Value, values[i].DbType, size, precision), new SimpleParameterInfo(values[i].Value, values[i].DbType, size, precision) };
                 yield return new object[] { new SimpleParameterInfo(values[i].Value, values[i].DbType, size, precision, scale), new SimpleParameterInfo(values[i].Value, values[i].DbType, size, precision, scale) };
-                yield return new object[] { new SimpleParameterInfo(null, values[i].Value, values[i].DbType, ParameterDirection.Input, size, precision, scale), new SimpleParameterInfo(null, values[i].Value, values[i].DbType, ParameterDirection.Input, size, precision, scale) };
             }
         }
     }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleParameterInfoTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleParameterInfoTests.cs
@@ -26,14 +26,14 @@ public class SimpleParameterInfoTests
 
     [Theory]
     [AutoData]
-    public void InternalConstructor_InitialisesSimpleParameterInfo_ReturnsSimpleParameterInfo(string name, object value, DbType dbType, ParameterDirection direction, int size, byte precision, byte scale)
+    public void InternalConstructor_InitialisesSimpleParameterInfo_ReturnsSimpleParameterInfo(string name, object value, DbType dbType, int size, byte precision, byte scale)
     {
         // Act
-        var sut = new SimpleParameterInfo(name, value, dbType, direction, size, precision, scale);
+        var sut = new SimpleParameterInfo(name, value, dbType, size, precision, scale);
 
         // Assert
         sut.Value.Should().Be(value);
-        sut.Direction.Should().Be(direction);
+        sut.Direction.Should().Be(ParameterDirection.Input);
         sut.DbType.Should().Be(dbType);
         sut.Size.Should().Be(size);
         sut.Precision.Should().Be(precision);

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/SimpleSqlBuilder.UnitTests.csproj
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/SimpleSqlBuilder.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
         <IsUnitTestProject>true</IsUnitTestProject>
         <RootNamespace>Dapper.SimpleSqlBuilder.UnitTests</RootNamespace>
         <AssemblyName>Dapper.SimpleSqlBuilder.UnitTests</AssemblyName>
@@ -11,5 +11,4 @@
         <ProjectReference Include="..\..\..\Builder\SimpleSqlBuilder\SimpleSqlBuilder.csproj" />
         <ProjectReference Include="..\SimpleSqlBuilder.UnitTestHelpers\SimpleSqlBuilder.UnitTestHelpers.csproj" />
     </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Description

Dropped `net462` target. However, the library still targets `netstandard2.0` which supports `net462` to `net481`.

- Updated target framework from net462 to net48 across multiple projects. 
- Refactored Product class: removed TypeId and Description, added ProductCode.
- Removed AutoFixture dependency and updated SQL queries accordingly.
-  Adjusted package references and preprocessor directives. 
- Updated SimpleParameterInfo to default Direction to Input.

<!--Please include a summary of the change and which issue is fixed or closed.-->
<!--Note any issues that are resolved in the is PR e.g. Closes #3213 or Fixes #3412 -->

## Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🔥 Hotfix (a major bugfix that has to be merged asap)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠 Enhancements (improvements to existing features)
- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] 📦 Other change

## Checklist
<!-- Ensure you have completed the checklist-->
- [x] My change follows the guidelines outlined in the [contributing](https://github.com/mishael-o/Dapper.SimpleSqlBuilder/blob/main/docs/CONTRIBUTING.md) document.
