### PR TITLE
Fix `CollectionParameterFormat` construction logic when set to use the right values.

### DIFF
--- a/src/Builder/SimpleSqlBuilder.DependencyInjection/Core/SimpleBuilderOptions.cs
+++ b/src/Builder/SimpleSqlBuilder.DependencyInjection/Core/SimpleBuilderOptions.cs
@@ -111,9 +111,9 @@ public sealed class SimpleBuilderOptions
     private void UpdateCollectionParameterFormat()
     {
 #if NET8_0_OR_GREATER
-        CollectionParameterFormat = System.Text.CompositeFormat.Parse(DatabaseParameterPrefix + CollectionParameterTemplateFormat);
+        CollectionParameterFormat = System.Text.CompositeFormat.Parse(DatabaseParameterNameTemplate + CollectionParameterTemplateFormat);
 #else
-        CollectionParameterFormat = DatabaseParameterPrefix + CollectionParameterTemplateFormat;
+        CollectionParameterFormat = DatabaseParameterNameTemplate + CollectionParameterTemplateFormat;
 #endif
     }
 }

--- a/src/Builder/SimpleSqlBuilder/Core/SimpleBuilderSettings.cs
+++ b/src/Builder/SimpleSqlBuilder/Core/SimpleBuilderSettings.cs
@@ -157,9 +157,9 @@ public sealed class SimpleBuilderSettings
     private static void UpdateCollectionParameterFormat()
     {
 #if NET8_0_OR_GREATER
-        Instance.CollectionParameterFormat = System.Text.CompositeFormat.Parse(Instance.DatabaseParameterPrefix + Instance.CollectionParameterTemplateFormat);
+        Instance.CollectionParameterFormat = System.Text.CompositeFormat.Parse(Instance.DatabaseParameterNameTemplate + Instance.CollectionParameterTemplateFormat);
 #else
-        Instance.CollectionParameterFormat = Instance.DatabaseParameterPrefix + Instance.CollectionParameterTemplateFormat;
+        Instance.CollectionParameterFormat = Instance.DatabaseParameterNameTemplate + Instance.CollectionParameterTemplateFormat;
 #endif
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Core/SimpleBuilderOptionsTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Core/SimpleBuilderOptionsTests.cs
@@ -86,9 +86,9 @@ public class SimpleBuilderOptionsTests
         sut.DatabaseParameterNameTemplate.Should().Be(parameterNameTemplate);
         sut.DatabaseParameterPrefix.Should().Be(parameterPrefix);
 #if NET8_0_OR_GREATER
-        sut.CollectionParameterFormat.Format.Should().Be(parameterPrefix + collectionParameterTemplateFormat);
+        sut.CollectionParameterFormat.Format.Should().Be(parameterNameTemplate + collectionParameterTemplateFormat);
 #else
-        sut.CollectionParameterFormat.Should().Be(parameterPrefix + collectionParameterTemplateFormat);
+        sut.CollectionParameterFormat.Should().Be(parameterNameTemplate + collectionParameterTemplateFormat);
 #endif
         sut.ReuseParameters.Should().Be(reuseParameters);
         sut.UseLowerCaseClauses.Should().Be(useLowerCaseClauses);

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleBuilderSettingsTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleBuilderSettingsTests.cs
@@ -79,7 +79,7 @@ public class SimpleBuilderSettingsTests
         bool useLowerCaseClauses)
     {
         // Arrange
-        var expectedCollectionParameterFormat = parameterPrefix + collectionParameterTemplateFormat;
+        var expectedCollectionParameterFormat = parameterNameTemplate + collectionParameterTemplateFormat;
 
         // Act
         SimpleBuilderSettings.Configure(parameterNameTemplate, parameterPrefix, collectionParameterTemplateFormat, reuseParameters, useLowerCaseClauses);
@@ -114,6 +114,7 @@ public class SimpleBuilderSettingsTests
         const string expectedParameterNameTemplate = "prm";
         const string expectedParameterPrefix = "@";
         const string expectedCollectionParameterTemplateFormat = "cl{0}";
+        const string expectedCollectionParameterFormat = expectedParameterNameTemplate + expectedCollectionParameterTemplateFormat;
         const bool expectedReuseParameters = false;
         const bool expectedUseLowerCaseClauses = false;
 
@@ -131,6 +132,11 @@ public class SimpleBuilderSettingsTests
         SimpleBuilderSettings.Instance.DatabaseParameterNameTemplate.Should().Be(expectedParameterNameTemplate);
         SimpleBuilderSettings.Instance.DatabaseParameterPrefix.Should().Be(expectedParameterPrefix);
         SimpleBuilderSettings.Instance.CollectionParameterTemplateFormat.Should().Be(expectedCollectionParameterTemplateFormat);
+#if NET8_0_OR_GREATER
+        SimpleBuilderSettings.Instance.CollectionParameterFormat.Format.Should().Be(expectedCollectionParameterFormat);
+#else
+        SimpleBuilderSettings.Instance.CollectionParameterFormat.Should().Be(expectedCollectionParameterFormat);
+#endif
         SimpleBuilderSettings.Instance.ReuseParameters.Should().Be(expectedReuseParameters);
         SimpleBuilderSettings.Instance.UseLowerCaseClauses.Should().Be(expectedUseLowerCaseClauses);
     }


### PR DESCRIPTION
## Description
Fix `CollectionParameterFormat` construction logic when set to use the right values.

-  `CollectionParameterFormat` in `SimpleBuilderOptions` and `SimpleBuilderSettings` fixed to use `DatabaseParameterNameTemplate` instead of `DatabaseParameterPrefix`.
-  Corresponding tests in `SimpleBuilderOptionsTests` and `SimpleBuilderSettingsTests` are updated to reflect this change, checking for `DatabaseParameterNameTemplate` concatenation.
-  Conditional compilation directives (`#if NET8_0_OR_GREATER`) are added to handle framework-specific differences.
- Additional assertions are included in `SimpleBuilderSettingsTests` to verify the correct format of `CollectionParameterFormat`.

<!--Please include a summary of the change and which issue is fixed or closed.-->
<!--Note any issues that are resolved in the is PR e.g. Closes #3213 or Fixes #3412 -->

## Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🔥 Hotfix (a major bugfix that has to be merged asap)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠 Enhancements (improvements to existing features)
- [x] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] 📦 Other change

## Checklist
<!-- Ensure you have completed the checklist-->
- [x] My change follows the guidelines outlined in the [contributing](https://github.com/mishael-o/Dapper.SimpleSqlBuilder/blob/main/docs/CONTRIBUTING.md) document.
