### PR TITLE
Refactored unit tests to use `Shouldly` and removed `FluentAssertions`.

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,7 +22,7 @@
         <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
         <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
         <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-        <PackageVersion Include="FluentAssertions" Version="7.2.0" />
+        <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Shouldly" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
@@ -23,7 +23,7 @@
         </PackageReference>
         <Using Include="AutoFixture" />
         <Using Include="AutoFixture.Xunit2" />
-        <Using Include="FluentAssertions" />
+        <Using Include="Shouldly" />
         <Using Include="Xunit" />
     </ItemGroup>
 

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlFluentTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlFluentTests.cs
@@ -46,7 +46,8 @@ public class MSSqlFluentTests : IAsyncLifetime
 
         // Assert
         var insertCount = await connection.ExecuteScalarAsync<int>(insertCountBuilder.Sql, insertCountBuilder.Parameters);
-        result.Should().Be(1).And.Be(insertCount);
+        result.ShouldBe(1);
+        result.ShouldBe(insertCount);
     }
 
     [Fact]
@@ -83,7 +84,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -116,7 +117,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -152,7 +153,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -178,7 +179,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -204,7 +205,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -233,7 +234,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -264,11 +265,11 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         var updatedProduct = await connection.QuerySingleAsync<Product>(getUpdatedProduct.Sql, getUpdatedProduct.Parameters);
-        updatedProduct.TypeId.Should().Be(mssqlTestsFixture.SeedProductTypes[0].Id);
-        updatedProduct.CreatedDate.Should().Be(createdDate);
+        updatedProduct.TypeId.ShouldBe(mssqlTestsFixture.SeedProductTypes[0].Id);
+        updatedProduct.CreatedDate.ShouldBe(createdDate);
     }
 
     [Fact]
@@ -296,10 +297,10 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         var countResult = await connection.ExecuteScalarAsync<int>(checkDataExistsBuilder.Sql, checkDataExistsBuilder.Parameters);
-        countResult.Should().Be(0);
+        countResult.ShouldBe(0);
     }
 
     public Task InitializeAsync()

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlFluentTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlFluentTests.cs
@@ -84,7 +84,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -179,7 +179,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -205,7 +205,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -234,7 +234,7 @@ public class MSSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlTests.cs
@@ -101,7 +101,7 @@ public class MSSqlTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MSSql/MSSqlTests.cs
@@ -42,7 +42,7 @@ public class MSSqlTests : IAsyncLifetime
         var result = await connection.ExecuteScalarAsync<bool>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class MSSqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(products.Length);
+        result.ShouldBe(products.Length);
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class MSSqlTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class MSSqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         builder.Reset();
         builder.AppendIntact($"""
@@ -134,7 +134,7 @@ public class MSSqlTests : IAsyncLifetime
             WHERE {nameof(Product.Tag):raw} = {tag}
             """);
         var expectedCreatedDates = await connection.QueryAsync<DateTime>(builder.Sql, builder.Parameters);
-        expectedCreatedDates.Should().AllBeEquivalentTo(createdDate);
+        expectedCreatedDates.ShouldAllBe(date => date == createdDate);
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class MSSqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         builder.Reset();
         builder.AppendIntact($"""
@@ -168,7 +168,7 @@ public class MSSqlTests : IAsyncLifetime
             END
             """);
         var dataExists = await connection.ExecuteScalarAsync<bool>(builder.Sql, builder.Parameters);
-        dataExists.Should().BeFalse();
+        dataExists.ShouldBeFalse();
     }
 
     [Fact]
@@ -190,8 +190,8 @@ public class MSSqlTests : IAsyncLifetime
         await connection.ExecuteAsync(builder.Sql, builder.Parameters, commandType: CommandType.StoredProcedure);
 
         // Assert
-        builder.GetValue<int>(productIdParamName).Should().NotBe(default);
-        builder.GetValue<int>(resultParamName).Should().Be(1);
+        builder.GetValue<int>(productIdParamName).ShouldNotBe(default);
+        builder.GetValue<int>(resultParamName).ShouldBe(1);
     }
 
     public Task InitializeAsync()

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlFluentTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlFluentTests.cs
@@ -84,7 +84,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -206,7 +206,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlFluentTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlFluentTests.cs
@@ -46,7 +46,8 @@ public class MySqlFluentTests : IAsyncLifetime
 
         // Assert
         var insertCount = await connection.ExecuteScalarAsync<int>(insertCountBuilder.Sql, insertCountBuilder.Parameters);
-        result.Should().Be(1).And.Be(insertCount);
+        result.ShouldBe(1);
+        result.ShouldBe(insertCount);
     }
 
     [Fact]
@@ -83,7 +84,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -116,7 +117,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -153,7 +154,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -179,7 +180,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -205,7 +206,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -234,7 +235,7 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -265,11 +266,11 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         var updatedProduct = await connection.QuerySingleAsync<Product>(getUpdatedProduct.Sql, getUpdatedProduct.Parameters);
-        updatedProduct.TypeId.Should().Be(mySqlTestsFixture.SeedProductTypes[0].Id);
-        updatedProduct.CreatedDate.Should().Be(createdDate);
+        updatedProduct.TypeId.ShouldBe(mySqlTestsFixture.SeedProductTypes[0].Id);
+        updatedProduct.CreatedDate.ShouldBe(createdDate);
     }
 
     [Fact]
@@ -297,10 +298,10 @@ public class MySqlFluentTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         var countResult = await connection.ExecuteScalarAsync<int>(checkDataExistsBuilder.Sql, checkDataExistsBuilder.Parameters);
-        countResult.Should().Be(0);
+        countResult.ShouldBe(0);
     }
 
     public Task InitializeAsync()

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTests.cs
@@ -101,7 +101,7 @@ public class MySqlTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/MySql/MySqlTests.cs
@@ -42,7 +42,7 @@ public class MySqlTests : IAsyncLifetime
         var result = await connection.ExecuteScalarAsync<bool>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class MySqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(products.Length);
+        result.ShouldBe(products.Length);
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class MySqlTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class MySqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         builder.Reset();
         builder.AppendIntact($"""
@@ -134,7 +134,7 @@ public class MySqlTests : IAsyncLifetime
             WHERE {nameof(Product.Tag):raw} = {tag}
             """);
         var expectedCreatedDates = await connection.QueryAsync<DateTime>(builder.Sql, builder.Parameters);
-        expectedCreatedDates.Should().AllBeEquivalentTo(createdDate);
+        expectedCreatedDates.ShouldAllBe(date => date == createdDate);
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class MySqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         builder.Reset();
         builder.AppendIntact($"""
@@ -168,7 +168,7 @@ public class MySqlTests : IAsyncLifetime
             END
             """);
         var dataExists = await connection.ExecuteScalarAsync<bool>(builder.Sql, builder.Parameters);
-        dataExists.Should().BeFalse();
+        dataExists.ShouldBeFalse();
     }
 
     [Fact]
@@ -190,8 +190,8 @@ public class MySqlTests : IAsyncLifetime
         await connection.ExecuteAsync(builder.Sql, builder.Parameters, commandType: CommandType.StoredProcedure);
 
         // Assert
-        builder.GetValue<int>(productIdParamName).Should().NotBe(default);
-        builder.GetValue<int>(resultParamName).Should().Be(1);
+        builder.GetValue<int>(productIdParamName).ShouldNotBe(default);
+        builder.GetValue<int>(resultParamName).ShouldBe(1);
     }
 
     public Task InitializeAsync()

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlFluentTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlFluentTests.cs
@@ -46,7 +46,8 @@ public class PostgreSqlFluentTests : IAsyncLifetime
 
         // Assert
         var insertCount = await connection.ExecuteScalarAsync<int>(insertCountBuilder.Sql, insertCountBuilder.Parameters);
-        result.Should().Be(1).And.Be(insertCount);
+        result.ShouldBe(1);
+        insertCount.ShouldBe(1);
     }
 
     [Fact]
@@ -83,7 +84,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -116,7 +117,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -149,7 +150,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -182,7 +183,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -218,7 +219,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -254,7 +255,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(paginatedProducts, option => option.WithStrictOrdering());
+        result.ShouldBe(paginatedProducts);
     }
 
     [Fact]
@@ -280,7 +281,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -306,7 +307,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -335,7 +336,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -366,11 +367,11 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         var updatedProduct = await connection.QuerySingleAsync<Product>(getUpdatedProduct.Sql, getUpdatedProduct.Parameters);
-        updatedProduct.TypeId.Should().Be(postgreSqlTestsFixture.SeedProductTypes[0].Id);
-        updatedProduct.CreatedDate.Should().Be(createdDate);
+        updatedProduct.TypeId.ShouldBe(postgreSqlTestsFixture.SeedProductTypes[0].Id);
+        updatedProduct.CreatedDate.ShouldBe(createdDate);
     }
 
     [Fact]
@@ -398,10 +399,10 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         var countResult = await connection.ExecuteScalarAsync<int>(checkDataExistsBuilder.Sql, checkDataExistsBuilder.Parameters);
-        countResult.Should().Be(0);
+        countResult.ShouldBe(0);
     }
 
     public Task InitializeAsync()

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlFluentTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlFluentTests.cs
@@ -84,7 +84,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -281,7 +281,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -307,7 +307,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]
@@ -336,7 +336,7 @@ public class PostgreSqlFluentTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlTests.cs
@@ -38,7 +38,7 @@ public class PostgreSqlTests : IAsyncLifetime
         var result = await connection.ExecuteScalarAsync<bool>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class PostgreSqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(products.Length);
+        result.ShouldBe(products.Length);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class PostgreSqlTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().BeEquivalentTo(products);
+        result.ShouldBeEquivalentTo(products);
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class PostgreSqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         builder.Reset();
         builder.AppendIntact($"""
@@ -130,7 +130,7 @@ public class PostgreSqlTests : IAsyncLifetime
             WHERE {nameof(Product.Tag):raw} = {tag}
             """);
         var expectedCreatedDates = await connection.QueryAsync<DateTime>(builder.Sql, builder.Parameters);
-        expectedCreatedDates.Should().AllBeEquivalentTo(createdDate);
+        expectedCreatedDates.ShouldAllBe(date => date == createdDate);
     }
 
     [Fact]
@@ -153,12 +153,12 @@ public class PostgreSqlTests : IAsyncLifetime
         var result = await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        result.Should().Be(count);
+        result.ShouldBe(count);
 
         builder.Reset();
         builder.AppendIntact($"SELECT EXISTS (SELECT 1 FROM {nameof(Product):raw} WHERE {nameof(Product.Tag):raw} = {tag})");
         var dataExists = await connection.ExecuteScalarAsync<bool>(builder.Sql, builder.Parameters);
-        dataExists.Should().BeFalse();
+        dataExists.ShouldBeFalse();
     }
 
     [Fact]
@@ -180,8 +180,8 @@ public class PostgreSqlTests : IAsyncLifetime
         await connection.ExecuteAsync(builder.Sql, builder.Parameters);
 
         // Assert
-        builder.GetValue<int>(productIdParamName).Should().NotBe(default);
-        builder.GetValue<int>(resultParamName).Should().Be(1);
+        builder.GetValue<int>(productIdParamName).ShouldNotBe(default);
+        builder.GetValue<int>(resultParamName).ShouldBe(1);
     }
 
     public Task InitializeAsync()

--- a/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlTests.cs
+++ b/src/Tests/IntegrationTests/SimpleSqlBuilder.IntegrationTests/PostgreSql/PostgreSqlTests.cs
@@ -97,7 +97,7 @@ public class PostgreSqlTests : IAsyncLifetime
         var result = await connection.QueryAsync<Product>(builder.Sql, builder.Parameters);
 
         // Assert
-        result.ShouldBeEquivalentTo(products);
+        result.ShouldBe(products, ignoreOrder: true);
     }
 
     [Fact]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Core/BuilderFactoryInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Core/BuilderFactoryInterpolatedStringHandlerTests.cs
@@ -12,8 +12,8 @@ public class BuilderFactoryInterpolatedStringHandlerTests
         Action act = () => _ = new BuilderFactoryInterpolatedStringHandler(0, 0, builderFactory);
 
         // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("builderFactory");
+        act.ShouldThrow<ArgumentNullException>()
+           .ParamName.ShouldBe("builderFactory");
     }
 
     [Theory]
@@ -29,8 +29,8 @@ public class BuilderFactoryInterpolatedStringHandlerTests
         Action act = () => _ = new BuilderFactoryInterpolatedStringHandler(0, 0, builderFactoryMock.Object);
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("ISimpleBuilder.Create does not return a builder that implements IBuilderFormatter.");
+        act.ShouldThrow<InvalidOperationException>()
+           .Message.ShouldBe("ISimpleBuilder.Create does not return a builder that implements IBuilderFormatter.");
     }
 
     [Theory]
@@ -85,7 +85,7 @@ public class BuilderFactoryInterpolatedStringHandlerTests
         };
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("The formatter is null. Ensure BuilderFactoryInterpolatedStringHandler is properly initialized.");
+        act.ShouldThrow<InvalidOperationException>()
+           .Message.ShouldBe("The formatter is null. Ensure BuilderFactoryInterpolatedStringHandler is properly initialized.");
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Core/SimpleBuilderFactoryTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Core/SimpleBuilderFactoryTests.cs
@@ -20,8 +20,8 @@ public class SimpleBuilderFactoryTests
         var result = sut.Create();
 
         // Assert
-        result.Should().BeOfType<SqlBuilder>();
-        result.ParameterNames.Should().HaveCount(0);
+        result.ShouldBeOfType<SqlBuilder>();
+        result.ParameterNames.ShouldBeEmpty();
     }
 
     [Theory]
@@ -42,11 +42,11 @@ public class SimpleBuilderFactoryTests
         var result = sut.Create($"SELECT x.*, (SELECT DESC FROM DESC_TABLE WHERE Id = {id}) FROM TABLE WHERE Id = {id:raw} AND Type IN {types}");
 
         // Assert
-        result.Should().BeOfType<SqlBuilder>();
-        result.Sql.Should().Be(expectedSql);
-        result.ParameterNames.Should().HaveCount(2);
-        result.GetValue<int>("p0").Should().Be(id);
-        result.GetValue<string[]>("pc1_").Should().BeEquivalentTo(types);
+        result.ShouldBeOfType<SqlBuilder>();
+        result.Sql.ShouldBe(expectedSql);
+        result.ParameterNames.Count().ShouldBe(2);
+        result.GetValue<int>("p0").ShouldBe(id);
+        result.GetValue<string[]>("pc1_").ShouldBe(types);
     }
 
     [Theory]
@@ -70,11 +70,11 @@ public class SimpleBuilderFactoryTests
             reuseParameters: true);
 
         // Assert
-        result.Should().BeOfType<SqlBuilder>();
-        result.Sql.Should().Be(expectedSql);
-        result.GetValue<int>("p0").Should().Be(id);
-        result.GetValue<string[]>("pc1_").Should().BeEquivalentTo(types);
-        result.ParameterNames.Should().HaveCount(2);
+        result.ShouldBeOfType<SqlBuilder>();
+        result.Sql.ShouldBe(expectedSql);
+        result.GetValue<int>("p0").ShouldBe(id);
+        result.GetValue<string[]>("pc1_").ShouldBe(types);
+        result.ParameterNames.Count().ShouldBe(2);
     }
 
     [Theory]
@@ -95,7 +95,7 @@ public class SimpleBuilderFactoryTests
         var result = sut.CreateFluent(parameterPrefix, reuseParameters, useLowerCaseClauses);
 
         // Assert
-        result.Should().BeOfType<FluentSqlBuilder>();
+        result.ShouldBeOfType<FluentSqlBuilder>();
     }
 
     [Theory]
@@ -124,11 +124,11 @@ public class SimpleBuilderFactoryTests
             .Where($"Type IN {types}");
 
         // Assert
-        result.Should().BeOfType<FluentSqlBuilder>();
-        result.Sql.Should().Be(expectedSql);
-        result.ParameterNames.Should().HaveCount(2);
-        result.GetValue<int>("p0").Should().Be(id);
-        result.GetValue<string[]>("pc1_").Should().BeEquivalentTo(types);
+        result.ShouldBeOfType<FluentSqlBuilder>();
+        result.Sql.ShouldBe(expectedSql);
+        result.ParameterNames.Count().ShouldBe(2);
+        result.GetValue<int>("p0").ShouldBe(id);
+        result.GetValue<string[]>("pc1_").ShouldBe(types);
     }
 
     [Theory]
@@ -157,10 +157,10 @@ public class SimpleBuilderFactoryTests
             .Where($"Type IN {types}");
 
         // Assert
-        result.Should().BeOfType<FluentSqlBuilder>();
-        result.Sql.Should().Be(expectedSql);
-        result.ParameterNames.Should().HaveCount(2);
-        result.GetValue<int>("p0").Should().Be(id);
-        result.GetValue<string[]>("pc1_").Should().BeEquivalentTo(types);
+        result.ShouldBeOfType<FluentSqlBuilder>();
+        result.Sql.ShouldBe(expectedSql);
+        result.ParameterNames.Count().ShouldBe(2);
+        result.GetValue<int>("p0").ShouldBe(id);
+        result.GetValue<string[]>("pc1_").ShouldBe(types);
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Core/SimpleBuilderOptionsTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Core/SimpleBuilderOptionsTests.cs
@@ -12,9 +12,9 @@ public class SimpleBuilderOptionsTests
         var act = () => sut.DatabaseParameterNameTemplate = value;
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage($"'{nameof(SimpleBuilderOptions.DatabaseParameterNameTemplate)}' cannot be null, empty, or white-space.*")
-            .WithParameterName(nameof(SimpleBuilderOptions.DatabaseParameterNameTemplate));
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith($"'{nameof(SimpleBuilderOptions.DatabaseParameterNameTemplate)}' cannot be null, empty, or white-space.");
+        exception.ParamName.ShouldBe(nameof(SimpleBuilderOptions.DatabaseParameterNameTemplate));
     }
 
     [Theory]
@@ -27,9 +27,9 @@ public class SimpleBuilderOptionsTests
         var act = () => sut.DatabaseParameterPrefix = value;
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage($"'{nameof(SimpleBuilderOptions.DatabaseParameterPrefix)}' cannot be null, empty, or white-space.*")
-            .WithParameterName(nameof(SimpleBuilderOptions.DatabaseParameterPrefix));
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith($"'{nameof(SimpleBuilderOptions.DatabaseParameterPrefix)}' cannot be null, empty, or white-space.");
+        exception.ParamName.ShouldBe(nameof(SimpleBuilderOptions.DatabaseParameterPrefix));
     }
 
     [Theory]
@@ -42,9 +42,9 @@ public class SimpleBuilderOptionsTests
         var act = () => sut.CollectionParameterTemplateFormat = value;
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage($"'{nameof(SimpleBuilderOptions.CollectionParameterTemplateFormat)}' cannot be null, empty, or white-space.*")
-            .WithParameterName(nameof(SimpleBuilderOptions.CollectionParameterTemplateFormat));
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith($"'{nameof(SimpleBuilderOptions.CollectionParameterTemplateFormat)}' cannot be null, empty, or white-space.");
+        exception.ParamName.ShouldBe(nameof(SimpleBuilderOptions.CollectionParameterTemplateFormat));
     }
 
     [Theory]
@@ -58,9 +58,9 @@ public class SimpleBuilderOptionsTests
         var act = () => sut.CollectionParameterTemplateFormat = value;
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage($"'{nameof(SimpleBuilderOptions.CollectionParameterTemplateFormat)}' must contain a format placeholder '{{0}}' for the index.*")
-            .WithParameterName(nameof(SimpleBuilderOptions.CollectionParameterTemplateFormat));
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith($"'{nameof(SimpleBuilderOptions.CollectionParameterTemplateFormat)}' must contain a format placeholder '{{0}}' for the index.");
+        exception.ParamName.ShouldBe(nameof(SimpleBuilderOptions.CollectionParameterTemplateFormat));
     }
 
     [Theory]
@@ -83,14 +83,14 @@ public class SimpleBuilderOptionsTests
         sut.UseLowerCaseClauses = useLowerCaseClauses;
 
         // Assert
-        sut.DatabaseParameterNameTemplate.Should().Be(parameterNameTemplate);
-        sut.DatabaseParameterPrefix.Should().Be(parameterPrefix);
+        sut.DatabaseParameterNameTemplate.ShouldBe(parameterNameTemplate);
+        sut.DatabaseParameterPrefix.ShouldBe(parameterPrefix);
 #if NET8_0_OR_GREATER
-        sut.CollectionParameterFormat.Format.Should().Be(parameterNameTemplate + collectionParameterTemplateFormat);
+        sut.CollectionParameterFormat.Format.ShouldBe(parameterNameTemplate + collectionParameterTemplateFormat);
 #else
-        sut.CollectionParameterFormat.Should().Be(parameterNameTemplate + collectionParameterTemplateFormat);
+        sut.CollectionParameterFormat.ShouldBe(parameterNameTemplate + collectionParameterTemplateFormat);
 #endif
-        sut.ReuseParameters.Should().Be(reuseParameters);
-        sut.UseLowerCaseClauses.Should().Be(useLowerCaseClauses);
+        sut.ReuseParameters.ShouldBe(reuseParameters);
+        sut.UseLowerCaseClauses.ShouldBe(useLowerCaseClauses);
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.DependencyInjection.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -16,8 +16,8 @@ public class ServiceCollectionExtensionsTests
         var act = () => sut.AddSimpleSqlBuilder();
 
         // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("service");
+        act.ShouldThrow<ArgumentNullException>()
+            .ParamName.ShouldBe("service");
     }
 
     [Theory]
@@ -35,12 +35,12 @@ public class ServiceCollectionExtensionsTests
         var serviceDescriptor = sut.First(x => x.ServiceType == typeof(ISimpleBuilder));
         var configuredOptions = provider.GetRequiredService<IOptionsMonitor<SimpleBuilderOptions>>();
 
-        serviceDescriptor.ImplementationType.Should().Be<SimpleBuilderFactory>();
-        serviceDescriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
-        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.Should().Be(SimpleBuilderSettings.DefaultDatabaseParameterNameTemplate);
-        configuredOptions.CurrentValue.DatabaseParameterPrefix.Should().Be(SimpleBuilderSettings.DefaultDatabaseParameterPrefix);
-        configuredOptions.CurrentValue.ReuseParameters.Should().Be(SimpleBuilderSettings.DefaultReuseParameters);
-        configuredOptions.CurrentValue.UseLowerCaseClauses.Should().Be(SimpleBuilderSettings.DefaultUseLowerCaseClauses);
+        serviceDescriptor.ImplementationType.ShouldBe(typeof(SimpleBuilderFactory));
+        serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.ShouldBe(SimpleBuilderSettings.DefaultDatabaseParameterNameTemplate);
+        configuredOptions.CurrentValue.DatabaseParameterPrefix.ShouldBe(SimpleBuilderSettings.DefaultDatabaseParameterPrefix);
+        configuredOptions.CurrentValue.ReuseParameters.ShouldBe(SimpleBuilderSettings.DefaultReuseParameters);
+        configuredOptions.CurrentValue.UseLowerCaseClauses.ShouldBe(SimpleBuilderSettings.DefaultUseLowerCaseClauses);
     }
 
     [Theory]
@@ -70,17 +70,17 @@ public class ServiceCollectionExtensionsTests
         var serviceDescriptor = sut.First(x => x.ServiceType == typeof(ISimpleBuilder));
         var configuredOptions = provider.GetRequiredService<IOptionsMonitor<SimpleBuilderOptions>>();
 
-        serviceDescriptor.ImplementationType.Should().Be<SimpleBuilderFactory>();
-        serviceDescriptor.Lifetime.Should().Be(serviceLifetime);
-        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.Should().Be(option.parameterNameTemplate);
-        configuredOptions.CurrentValue.DatabaseParameterPrefix.Should().Be(option.parameterPrefix);
-        configuredOptions.CurrentValue.ReuseParameters.Should().Be(option.reuseParameters);
-        configuredOptions.CurrentValue.UseLowerCaseClauses.Should().Be(option.userLowerCaseClauses);
+        serviceDescriptor.ImplementationType.ShouldBe(typeof(SimpleBuilderFactory));
+        serviceDescriptor.Lifetime.ShouldBe(serviceLifetime);
+        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.ShouldBe(option.parameterNameTemplate);
+        configuredOptions.CurrentValue.DatabaseParameterPrefix.ShouldBe(option.parameterPrefix);
+        configuredOptions.CurrentValue.ReuseParameters.ShouldBe(option.reuseParameters);
+        configuredOptions.CurrentValue.UseLowerCaseClauses.ShouldBe(option.userLowerCaseClauses);
     }
 
     [Theory]
     [AutoData]
-    public void AddSimpleSqlBuilder_ServiceCollectionIsNullWhenCofigurationFromConfigureAction_ThrowsArgumentNullException(Action<SimpleBuilderOptions> configure)
+    public void AddSimpleSqlBuilder_ServiceCollectionIsNullWhenConfigurationFromConfigureAction_ThrowsArgumentNullException(Action<SimpleBuilderOptions> configure)
     {
         // Arrange
         IServiceCollection sut = null!;
@@ -89,8 +89,8 @@ public class ServiceCollectionExtensionsTests
         var act = () => sut.AddSimpleSqlBuilder(configure);
 
         // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("service");
+        act.ShouldThrow<ArgumentNullException>()
+            .ParamName.ShouldBe("service");
     }
 
     [Theory]
@@ -104,8 +104,8 @@ public class ServiceCollectionExtensionsTests
         var act = () => sut.AddSimpleSqlBuilder(configure);
 
         // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("configure");
+        act.ShouldThrow<ArgumentNullException>()
+            .ParamName.ShouldBe("configure");
     }
 
     [Theory]
@@ -131,12 +131,12 @@ public class ServiceCollectionExtensionsTests
         var serviceDescriptor = sut.First(x => x.ServiceType == typeof(ISimpleBuilder));
         var configuredOptions = provider.GetRequiredService<IOptionsMonitor<SimpleBuilderOptions>>();
 
-        serviceDescriptor.ImplementationType.Should().Be<SimpleBuilderFactory>();
-        serviceDescriptor.Lifetime.Should().Be(serviceLifetime);
-        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.Should().Be(option.DatabaseParameterNameTemplate);
-        configuredOptions.CurrentValue.DatabaseParameterPrefix.Should().Be(option.DatabaseParameterPrefix);
-        configuredOptions.CurrentValue.ReuseParameters.Should().Be(option.ReuseParameters);
-        configuredOptions.CurrentValue.UseLowerCaseClauses.Should().Be(option.UseLowerCaseClauses);
+        serviceDescriptor.ImplementationType.ShouldBe(typeof(SimpleBuilderFactory));
+        serviceDescriptor.Lifetime.ShouldBe(serviceLifetime);
+        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.ShouldBe(option.DatabaseParameterNameTemplate);
+        configuredOptions.CurrentValue.DatabaseParameterPrefix.ShouldBe(option.DatabaseParameterPrefix);
+        configuredOptions.CurrentValue.ReuseParameters.ShouldBe(option.ReuseParameters);
+        configuredOptions.CurrentValue.UseLowerCaseClauses.ShouldBe(option.UseLowerCaseClauses);
     }
 
     [Theory]
@@ -150,8 +150,8 @@ public class ServiceCollectionExtensionsTests
         var act = () => sut.AddSimpleSqlBuilder(configSectionPath);
 
         // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("service");
+        act.ShouldThrow<ArgumentNullException>()
+            .ParamName.ShouldBe("service");
     }
 
     [Theory]
@@ -164,8 +164,8 @@ public class ServiceCollectionExtensionsTests
         var act = () => sut.AddSimpleSqlBuilder(configSectionPath);
 
         // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("configurationSectionPath");
+        act.ShouldThrow<ArgumentNullException>()
+            .ParamName.ShouldBe("configurationSectionPath");
     }
 
     [Theory]
@@ -183,12 +183,12 @@ public class ServiceCollectionExtensionsTests
         var serviceDescriptor = sut.First(x => x.ServiceType == typeof(ISimpleBuilder));
         var configuredOptions = provider.GetRequiredService<IOptionsMonitor<SimpleBuilderOptions>>();
 
-        serviceDescriptor.ImplementationType.Should().Be<SimpleBuilderFactory>();
-        serviceDescriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
-        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.Should().Be(SimpleBuilderSettings.DefaultDatabaseParameterNameTemplate);
-        configuredOptions.CurrentValue.DatabaseParameterPrefix.Should().Be(SimpleBuilderSettings.DefaultDatabaseParameterPrefix);
-        configuredOptions.CurrentValue.ReuseParameters.Should().Be(SimpleBuilderSettings.DefaultReuseParameters);
-        configuredOptions.CurrentValue.UseLowerCaseClauses.Should().Be(SimpleBuilderSettings.DefaultUseLowerCaseClauses);
+        serviceDescriptor.ImplementationType.ShouldBe(typeof(SimpleBuilderFactory));
+        serviceDescriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.ShouldBe(SimpleBuilderSettings.DefaultDatabaseParameterNameTemplate);
+        configuredOptions.CurrentValue.DatabaseParameterPrefix.ShouldBe(SimpleBuilderSettings.DefaultDatabaseParameterPrefix);
+        configuredOptions.CurrentValue.ReuseParameters.ShouldBe(SimpleBuilderSettings.DefaultReuseParameters);
+        configuredOptions.CurrentValue.UseLowerCaseClauses.ShouldBe(SimpleBuilderSettings.DefaultUseLowerCaseClauses);
     }
 
     [Theory]
@@ -219,11 +219,11 @@ public class ServiceCollectionExtensionsTests
         var serviceDescriptor = sut.First(x => x.ServiceType == typeof(ISimpleBuilder));
         var configuredOptions = provider.GetRequiredService<IOptionsMonitor<SimpleBuilderOptions>>();
 
-        serviceDescriptor.ImplementationType.Should().Be<SimpleBuilderFactory>();
-        serviceDescriptor.Lifetime.Should().Be(serviceLifetime);
-        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.Should().Be(option.parameterNameTemplate);
-        configuredOptions.CurrentValue.DatabaseParameterPrefix.Should().Be(option.parameterPrefix);
-        configuredOptions.CurrentValue.ReuseParameters.Should().Be(option.reuseParameters);
-        configuredOptions.CurrentValue.UseLowerCaseClauses.Should().Be(option.userLowerCaseClauses);
+        serviceDescriptor.ImplementationType.ShouldBe(typeof(SimpleBuilderFactory));
+        serviceDescriptor.Lifetime.ShouldBe(serviceLifetime);
+        configuredOptions.CurrentValue.DatabaseParameterNameTemplate.ShouldBe(option.parameterNameTemplate);
+        configuredOptions.CurrentValue.DatabaseParameterPrefix.ShouldBe(option.parameterPrefix);
+        configuredOptions.CurrentValue.ReuseParameters.ShouldBe(option.reuseParameters);
+        configuredOptions.CurrentValue.UseLowerCaseClauses.ShouldBe(option.userLowerCaseClauses);
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/BuilderTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/BuilderTests.cs
@@ -11,10 +11,10 @@ public class BuilderTests
         var sut = SimpleBuilder.Create();
 
         // Assert
-        sut.Should().BeOfType<SqlBuilder>();
-        sut.Sql.Should().BeEmpty();
-        sut.ParameterNames.Should().BeEmpty();
-        sut.Parameters.Should().BeOfType<DynamicParameters>();
+        sut.ShouldBeOfType<SqlBuilder>();
+        sut.Sql.ShouldBeEmpty();
+        sut.ParameterNames.ShouldBeEmpty();
+        sut.Parameters.ShouldBeOfType<DynamicParameters>();
     }
 
     [Fact]
@@ -27,8 +27,8 @@ public class BuilderTests
         var sut = SimpleBuilder.Create($"SELECT * FROM TABLE");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().BeEmpty();
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Theory]
@@ -42,10 +42,10 @@ public class BuilderTests
         var sut = SimpleBuilder.Create($"SELECT * FROM TABLE WHERE ID = {id:raw} AND WHERE NAME = {name} AND Age IN {ages}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Count().Should().Be(2);
-        sut.GetValue<string>("p0").Should().Be(name);
-        sut.GetValue<IEnumerable<int>>("pc1_").Should().BeEquivalentTo(ages);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<string>("p0").ShouldBe(name);
+        sut.GetValue<IEnumerable<int>>("pc1_").ShouldBe(ages);
     }
 
 #if !NET6_0_OR_GREATER
@@ -62,9 +62,9 @@ public class BuilderTests
         var result = sut.AppendIntact(formattable);
 
         // Assert
-        result.Should().Be(sut);
-        sut.Sql.Should().BeEmpty();
-        sut.ParameterNames.Should().BeEmpty();
+        result.ShouldBe(sut);
+        sut.Sql.ShouldBeEmpty();
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
 #endif
@@ -79,9 +79,9 @@ public class BuilderTests
         var result = sut.AppendIntact($"SELECT * FROM TABLE");
 
         // Assert
-        result.Should().Be(sut);
-        sut.Sql.Should().Be("SELECT * FROM TABLE");
-        sut.ParameterNames.Should().BeEmpty();
+        result.ShouldBe(sut);
+        sut.Sql.ShouldBe("SELECT * FROM TABLE");
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Theory]
@@ -97,10 +97,10 @@ public class BuilderTests
         sut.AppendIntact($"SELECT * FROM TABLE WHERE ID = {id:raw} AND WHERE NAME = {name} AND Age IN {ages}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Count().Should().Be(2);
-        sut.GetValue<string>("p0").Should().Be(name);
-        sut.GetValue<int[]>("pc1_").Should().BeEquivalentTo(ages);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<string>("p0").ShouldBe(name);
+        sut.GetValue<int[]>("pc1_").ShouldBe(ages);
     }
 
     [Theory]
@@ -116,11 +116,11 @@ public class BuilderTests
         sut.AppendIntact($"SELECT * FROM TABLE WHERE ID = {id} AND NAME = {name} AND Age IN {ages}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Count().Should().Be(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(name);
-        sut.GetValue<int[]>("pc2_").Should().BeEquivalentTo(ages);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(name);
+        sut.GetValue<int[]>("pc2_").ShouldBe(ages);
     }
 
     [Theory]
@@ -136,10 +136,10 @@ public class BuilderTests
         sut.AppendIntact($"SELECT * FROM TABLE WHERE ID = {id.DefineParam(System.Data.DbType.Int32)} AND NAME = {name} AND TYPE = '{type:raw}' AND SECOND_ID = {secondId:raw}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Count().Should().Be(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(name);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(name);
     }
 
     [Theory]
@@ -158,12 +158,12 @@ public class BuilderTests
         sut.AppendIntact($"SELECT * FROM ({innerQuery}) WHERE ROWNUM > {rowNum}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Count().Should().Be(4);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(name);
-        sut.GetValue<ICollection<int>>("pc2_").Should().BeEquivalentTo(ages);
-        sut.GetValue<int>("p3").Should().Be(rowNum);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(4);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(name);
+        sut.GetValue<ICollection<int>>("pc2_").ShouldBe(ages);
+        sut.GetValue<int>("p3").ShouldBe(rowNum);
     }
 
     [Theory]
@@ -176,7 +176,7 @@ public class BuilderTests
             .AppendIntact(condition, $"SELECT * FROM TABLE WHERE ID = {1}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
+        sut.Sql.ShouldBe(expectedSql);
     }
 
     [Theory]
@@ -192,11 +192,11 @@ public class BuilderTests
         sut.Append($"WHERE ID = {id} AND TypeId IN ({subQuery}) ROWNUM <= {rowNum:raw}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Count().Should().Be(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(typeCode);
-        sut.GetValue<HashSet<string>>("pc2_").Should().BeEquivalentTo(codes);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(typeCode);
+        sut.GetValue<HashSet<string>>("pc2_").ShouldBe(codes);
     }
 
     [Theory]
@@ -209,7 +209,7 @@ public class BuilderTests
             .Append(condition, $"WHERE ID = {1}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
+        sut.Sql.ShouldBe(expectedSql);
     }
 
     [Fact]
@@ -222,9 +222,9 @@ public class BuilderTests
         var result = sut.AppendNewLine();
 
         // Assert
-        result.Should().Be(sut);
-        sut.Sql.Should().Be(Environment.NewLine);
-        sut.ParameterNames.Should().BeEmpty();
+        result.ShouldBe(sut);
+        sut.Sql.ShouldBe(Environment.NewLine);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Theory]
@@ -236,7 +236,7 @@ public class BuilderTests
             .AppendNewLine(condition, $"WHERE ID = {1}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
+        sut.Sql.ShouldBe(expectedSql);
     }
 
     [Theory]
@@ -253,10 +253,10 @@ public class BuilderTests
         sut.AppendNewLine($"WHERE ID = {id} AND TypeId IN ({subQuery}) ROWNUM <= {rowNum:raw}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Count().Should().Be(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(typeCode);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(typeCode);
     }
 
     [Theory]
@@ -270,8 +270,8 @@ public class BuilderTests
         var result = sut.AddParameter(nameof(id), id);
 
         // Assert
-        result.Should().Be(sut);
-        sut.GetValue<int>(nameof(id)).Should().Be(id);
+        result.ShouldBe(sut);
+        sut.GetValue<int>(nameof(id)).ShouldBe(id);
     }
 
     [Theory]
@@ -289,9 +289,9 @@ public class BuilderTests
         var result = sut.AddDynamicParameters(dynamicParameters);
 
         // Assert
-        result.Should().Be(sut);
-        sut.GetValue<int>(param1Name).Should().Be(param1Value);
-        sut.GetValue<string>(param2Name).Should().Be(param2Value);
+        result.ShouldBe(sut);
+        sut.GetValue<int>(param1Name).ShouldBe(param1Value);
+        sut.GetValue<string>(param2Name).ShouldBe(param2Value);
     }
 
     [Theory]
@@ -305,9 +305,9 @@ public class BuilderTests
         var result = sut += $"SELECT * FROM TABLE WHERE ID = {id}";
 
         // Assert
-        result.Should().Be(sut);
-        sut.Sql.Should().Be("SELECT * FROM TABLE WHERE ID = @p0");
-        sut.GetValue<int>("p0").Should().Be(id);
+        result.ShouldBe(sut);
+        sut.Sql.ShouldBe("SELECT * FROM TABLE WHERE ID = @p0");
+        sut.GetValue<int>("p0").ShouldBe(id);
     }
 
     [Fact]
@@ -320,7 +320,8 @@ public class BuilderTests
         var act = () => sut += $"SELECT * FROM TABLE WHERE";
 
         // Assert
-        act.Should().Throw<ArgumentNullException>().WithParameterName("builder");
+        act.ShouldThrow<ArgumentNullException>()
+           .ParamName.ShouldBe("builder");
     }
 
     [Fact]
@@ -344,15 +345,15 @@ public class BuilderTests
             .AppendNewLine($"INSERT INTO TABLE VALUES ({model.Id}, {model.TypeId}, {model.Age}, {model.Name}, {model.MiddleName})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(7);
-        sut.GetValue<int>("p0").Should().Be(model.Id);
-        sut.GetValue<int>("p1").Should().Be(model.TypeId);
-        sut.GetValue<int?>("p2").Should().Be(model.Age);
-        sut.GetValue<string>("p3").Should().Be(model.Name);
-        sut.GetValue<string?>("p4").Should().Be(model.MiddleName);
-        sut.GetValue<int?>("p5").Should().Be(model.Age);
-        sut.GetValue<string?>("p6").Should().Be(model.MiddleName);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(7);
+        sut.GetValue<int>("p0").ShouldBe(model.Id);
+        sut.GetValue<int>("p1").ShouldBe(model.TypeId);
+        sut.GetValue<int?>("p2").ShouldBe(model.Age);
+        sut.GetValue<string>("p3").ShouldBe(model.Name);
+        sut.GetValue<string?>("p4").ShouldBe(model.MiddleName);
+        sut.GetValue<int?>("p5").ShouldBe(model.Age);
+        sut.GetValue<string?>("p6").ShouldBe(model.MiddleName);
     }
 
     [Fact]
@@ -365,8 +366,8 @@ public class BuilderTests
         sut.Reset();
 
         // Assert
-        sut.Sql.Should().BeEmpty();
-        sut.ParameterNames.Should().BeEmpty();
+        sut.Sql.ShouldBeEmpty();
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -381,9 +382,9 @@ public class BuilderTests
         sut.AppendIntact($"DELETE FROM TABLE WHERE ID = {id}");
 
         // Assert
-        sut.Sql.Should().Be("DELETE FROM TABLE WHERE ID = @p0");
-        sut.ParameterNames.Count().Should().Be(1);
-        sut.GetValue<int>("p0").Should().Be(id);
+        sut.Sql.ShouldBe("DELETE FROM TABLE WHERE ID = @p0");
+        sut.ParameterNames.Count().ShouldBe(1);
+        sut.GetValue<int>("p0").ShouldBe(id);
     }
 
     internal static class BuilderTestsData

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/Handlers/AppendIntactInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/Handlers/AppendIntactInterpolatedStringHandlerTests.cs
@@ -13,9 +13,9 @@ public class AppendIntactInterpolatedStringHandlerTests
         Action act = () => _ = new AppendIntactInterpolatedStringHandler(0, 0, builder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith("The builder must implement IBuilderFormatter.");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -26,9 +26,9 @@ public class AppendIntactInterpolatedStringHandlerTests
         Action act = () => _ = new AppendIntactInterpolatedStringHandler(0, 0, builderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith("The builder must implement IBuilderFormatter.");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -43,7 +43,7 @@ public class AppendIntactInterpolatedStringHandlerTests
         _ = new AppendIntactInterpolatedStringHandler(0, 0, condition, builderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/Handlers/AppendInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/Handlers/AppendInterpolatedStringHandlerTests.cs
@@ -13,9 +13,9 @@ public class AppendInterpolatedStringHandlerTests
         Action act = () => _ = new AppendInterpolatedStringHandler(0, 0, builder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith("The builder must implement IBuilderFormatter.");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -26,9 +26,9 @@ public class AppendInterpolatedStringHandlerTests
         Action act = () => _ = new AppendInterpolatedStringHandler(0, 0, builderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith("The builder must implement IBuilderFormatter.");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -57,7 +57,7 @@ public class AppendInterpolatedStringHandlerTests
         _ = new AppendInterpolatedStringHandler(0, 0, condition, builderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/Handlers/AppendNewLineInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/Handlers/AppendNewLineInterpolatedStringHandlerTests.cs
@@ -13,9 +13,9 @@ public class AppendNewLineInterpolatedStringHandlerTests
         Action act = () => _ = new AppendNewLineInterpolatedStringHandler(0, 0, builder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith("The builder must implement IBuilderFormatter.");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -26,9 +26,9 @@ public class AppendNewLineInterpolatedStringHandlerTests
         Action act = () => _ = new AppendNewLineInterpolatedStringHandler(0, 0, builderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith("The builder must implement IBuilderFormatter.");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -57,7 +57,7 @@ public class AppendNewLineInterpolatedStringHandlerTests
         _ = new AppendNewLineInterpolatedStringHandler(0, 0, condition, builderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/Handlers/BuilderInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/Handlers/BuilderInterpolatedStringHandlerTests.cs
@@ -16,8 +16,8 @@ public class BuilderInterpolatedStringHandlerTests
 
         // Assert
         var builder = sut.GetBuilder();
-        builder.Should().NotBeNull();
-        builder.Sql.Should().Be(value);
+        builder.ShouldNotBeNull();
+        builder.Sql.ShouldBe(value);
     }
 
     [Theory]
@@ -33,8 +33,8 @@ public class BuilderInterpolatedStringHandlerTests
 
         // Assert
         var builder = sut.GetBuilder();
-        builder.Should().NotBeNull();
-        builder.Sql.Should().Be(expectedSql);
+        builder.ShouldNotBeNull();
+        builder.Sql.ShouldBe(expectedSql);
     }
 
     [Fact]
@@ -48,8 +48,8 @@ public class BuilderInterpolatedStringHandlerTests
         };
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("The formatter is null. Ensure BuilderInterpolatedStringHandler is properly initialized.");
+        act.ShouldThrow<InvalidOperationException>()
+           .Message.ShouldBe("The formatter is null. Ensure BuilderInterpolatedStringHandler is properly initialized.");
     }
 }
 #endif

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleBuilderSettingsTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleBuilderSettingsTests.cs
@@ -17,16 +17,16 @@ public class SimpleBuilderSettingsTests
         SimpleBuilderSettings.Configure();
 
         // Assert
-        SimpleBuilderSettings.Instance.DatabaseParameterNameTemplate.Should().Be(SimpleBuilderSettings.DefaultDatabaseParameterNameTemplate);
-        SimpleBuilderSettings.Instance.DatabaseParameterPrefix.Should().Be(SimpleBuilderSettings.DefaultDatabaseParameterPrefix);
-        SimpleBuilderSettings.Instance.CollectionParameterTemplateFormat.Should().Be(SimpleBuilderSettings.DefaultCollectionParameterTemplateFormat);
+        SimpleBuilderSettings.Instance.DatabaseParameterNameTemplate.ShouldBe(SimpleBuilderSettings.DefaultDatabaseParameterNameTemplate);
+        SimpleBuilderSettings.Instance.DatabaseParameterPrefix.ShouldBe(SimpleBuilderSettings.DefaultDatabaseParameterPrefix);
+        SimpleBuilderSettings.Instance.CollectionParameterTemplateFormat.ShouldBe(SimpleBuilderSettings.DefaultCollectionParameterTemplateFormat);
 #if NET8_0_OR_GREATER
-        SimpleBuilderSettings.Instance.CollectionParameterFormat.Format.Should().Be(expectedCollectionParameterFormat);
+        SimpleBuilderSettings.Instance.CollectionParameterFormat.Format.ShouldBe(expectedCollectionParameterFormat);
 #else
-        SimpleBuilderSettings.Instance.CollectionParameterFormat.Should().Be(expectedCollectionParameterFormat);
+        SimpleBuilderSettings.Instance.CollectionParameterFormat.ShouldBe(expectedCollectionParameterFormat);
 #endif
-        SimpleBuilderSettings.Instance.ReuseParameters.Should().Be(SimpleBuilderSettings.DefaultReuseParameters);
-        SimpleBuilderSettings.Instance.UseLowerCaseClauses.Should().Be(SimpleBuilderSettings.DefaultUseLowerCaseClauses);
+        SimpleBuilderSettings.Instance.ReuseParameters.ShouldBe(SimpleBuilderSettings.DefaultReuseParameters);
+        SimpleBuilderSettings.Instance.UseLowerCaseClauses.ShouldBe(SimpleBuilderSettings.DefaultUseLowerCaseClauses);
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class SimpleBuilderSettingsTests
         var sut = SimpleBuilder.Create($"SELECT * FROM TABLE WHERE ID = {id}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.GetValue<int>($"{parameterNameTemplate}0").Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.GetValue<int>($"{parameterNameTemplate}0").ShouldBe(id);
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class SimpleBuilderSettingsTests
             .Where($"ID = {id}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.GetValue<int>($"{parameterNameTemplate}0").Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.GetValue<int>($"{parameterNameTemplate}0").ShouldBe(id);
     }
 
     [Theory]
@@ -85,16 +85,16 @@ public class SimpleBuilderSettingsTests
         SimpleBuilderSettings.Configure(parameterNameTemplate, parameterPrefix, collectionParameterTemplateFormat, reuseParameters, useLowerCaseClauses);
 
         // Assert
-        SimpleBuilderSettings.Instance.DatabaseParameterNameTemplate.Should().Be(parameterNameTemplate);
-        SimpleBuilderSettings.Instance.DatabaseParameterPrefix.Should().Be(parameterPrefix);
-        SimpleBuilderSettings.Instance.CollectionParameterTemplateFormat.Should().Be(collectionParameterTemplateFormat);
+        SimpleBuilderSettings.Instance.DatabaseParameterNameTemplate.ShouldBe(parameterNameTemplate);
+        SimpleBuilderSettings.Instance.DatabaseParameterPrefix.ShouldBe(parameterPrefix);
+        SimpleBuilderSettings.Instance.CollectionParameterTemplateFormat.ShouldBe(collectionParameterTemplateFormat);
 #if NET8_0_OR_GREATER
-        SimpleBuilderSettings.Instance.CollectionParameterFormat.Format.Should().Be(expectedCollectionParameterFormat);
+        SimpleBuilderSettings.Instance.CollectionParameterFormat.Format.ShouldBe(expectedCollectionParameterFormat);
 #else
-        SimpleBuilderSettings.Instance.CollectionParameterFormat.Should().Be(expectedCollectionParameterFormat);
+        SimpleBuilderSettings.Instance.CollectionParameterFormat.ShouldBe(expectedCollectionParameterFormat);
 #endif
-        SimpleBuilderSettings.Instance.ReuseParameters.Should().Be(reuseParameters);
-        SimpleBuilderSettings.Instance.UseLowerCaseClauses.Should().Be(useLowerCaseClauses);
+        SimpleBuilderSettings.Instance.ReuseParameters.ShouldBe(reuseParameters);
+        SimpleBuilderSettings.Instance.UseLowerCaseClauses.ShouldBe(useLowerCaseClauses);
     }
 
     [Theory]
@@ -129,16 +129,16 @@ public class SimpleBuilderSettingsTests
         SimpleBuilderSettings.Configure(parameterNameTemplate, parameterPrefix, collectionParameterTemplateFormat, reuseParameters, useLowerCaseClauses);
 
         // Assert
-        SimpleBuilderSettings.Instance.DatabaseParameterNameTemplate.Should().Be(expectedParameterNameTemplate);
-        SimpleBuilderSettings.Instance.DatabaseParameterPrefix.Should().Be(expectedParameterPrefix);
-        SimpleBuilderSettings.Instance.CollectionParameterTemplateFormat.Should().Be(expectedCollectionParameterTemplateFormat);
+        SimpleBuilderSettings.Instance.DatabaseParameterNameTemplate.ShouldBe(expectedParameterNameTemplate);
+        SimpleBuilderSettings.Instance.DatabaseParameterPrefix.ShouldBe(expectedParameterPrefix);
+        SimpleBuilderSettings.Instance.CollectionParameterTemplateFormat.ShouldBe(expectedCollectionParameterTemplateFormat);
 #if NET8_0_OR_GREATER
-        SimpleBuilderSettings.Instance.CollectionParameterFormat.Format.Should().Be(expectedCollectionParameterFormat);
+        SimpleBuilderSettings.Instance.CollectionParameterFormat.Format.ShouldBe(expectedCollectionParameterFormat);
 #else
-        SimpleBuilderSettings.Instance.CollectionParameterFormat.Should().Be(expectedCollectionParameterFormat);
+        SimpleBuilderSettings.Instance.CollectionParameterFormat.ShouldBe(expectedCollectionParameterFormat);
 #endif
-        SimpleBuilderSettings.Instance.ReuseParameters.Should().Be(expectedReuseParameters);
-        SimpleBuilderSettings.Instance.UseLowerCaseClauses.Should().Be(expectedUseLowerCaseClauses);
+        SimpleBuilderSettings.Instance.ReuseParameters.ShouldBe(expectedReuseParameters);
+        SimpleBuilderSettings.Instance.UseLowerCaseClauses.ShouldBe(expectedUseLowerCaseClauses);
     }
 
     [Theory]
@@ -152,8 +152,8 @@ public class SimpleBuilderSettingsTests
         var act = () => SimpleBuilderSettings.Configure(collectionParameterTemplateFormat: collectionParameterTemplateFormat);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage($"'{nameof(collectionParameterTemplateFormat)}' must contain a format placeholder '{{0}}' for the index.*")
-            .WithParameterName(nameof(collectionParameterTemplateFormat));
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith($"'{nameof(collectionParameterTemplateFormat)}' must contain a format placeholder '{{0}}' for the index.");
+        exception.ParamName.ShouldBe(nameof(collectionParameterTemplateFormat));
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleParameterInfoComparerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleParameterInfoComparerTests.cs
@@ -15,7 +15,7 @@ public class SimpleParameterInfoComparerTests
         var result = sut.Equals(param1, param2);
 
         // Assert
-        result.Should().BeFalse();
+        result.ShouldBeFalse();
     }
 
     [Theory]
@@ -29,7 +29,7 @@ public class SimpleParameterInfoComparerTests
         var result = sut.Equals(param1, param2);
 
         // Assert
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class SimpleParameterInfoComparerTests
         var hashCode = sut.GetHashCode(parameterInfo);
 
         // Assert
-        hashCode.Should().Be(expectedHashCode);
+        hashCode.ShouldBe(expectedHashCode);
     }
 
     private static class SimpleParameterInfoComparerTestCases

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleParameterInfoTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SimpleParameterInfoTests.cs
@@ -12,16 +12,16 @@ public class SimpleParameterInfoTests
         var sut = new SimpleParameterInfo(null, dbType, size, precision, scale);
 
         // Assert
-        sut.Value.Should().BeNull();
-        sut.Direction.Should().Be(ParameterDirection.Input);
-        sut.DbType.Should().Be(dbType);
-        sut.Size.Should().Be(size);
-        sut.Precision.Should().Be(precision);
-        sut.Scale.Should().Be(scale);
-        sut.Type.Should().BeNull();
-        sut.Name.Should().BeNull();
-        sut.HasValue.Should().BeFalse();
-        sut.HasName.Should().BeFalse();
+        sut.Value.ShouldBeNull();
+        sut.Direction.ShouldBe(ParameterDirection.Input);
+        sut.DbType.ShouldBe(dbType);
+        sut.Size.ShouldBe(size);
+        sut.Precision.ShouldBe(precision);
+        sut.Scale.ShouldBe(scale);
+        sut.Type.ShouldBeNull();
+        sut.Name.ShouldBeNull();
+        sut.HasValue.ShouldBeFalse();
+        sut.HasName.ShouldBeFalse();
     }
 
     [Theory]
@@ -32,16 +32,16 @@ public class SimpleParameterInfoTests
         var sut = new SimpleParameterInfo(name, value, dbType, size, precision, scale);
 
         // Assert
-        sut.Value.Should().Be(value);
-        sut.Direction.Should().Be(ParameterDirection.Input);
-        sut.DbType.Should().Be(dbType);
-        sut.Size.Should().Be(size);
-        sut.Precision.Should().Be(precision);
-        sut.Scale.Should().Be(scale);
-        sut.Type.Should().Be(value.GetType());
-        sut.Name.Should().Be(name);
-        sut.HasValue.Should().BeTrue();
-        sut.HasName.Should().BeTrue();
+        sut.Value.ShouldBe(value);
+        sut.Direction.ShouldBe(ParameterDirection.Input);
+        sut.DbType.ShouldBe(dbType);
+        sut.Size.ShouldBe(size);
+        sut.Precision.ShouldBe(precision);
+        sut.Scale.ShouldBe(scale);
+        sut.Type.ShouldBe(value.GetType());
+        sut.Name.ShouldBe(name);
+        sut.HasValue.ShouldBeTrue();
+        sut.HasName.ShouldBeTrue();
     }
 
     [Theory]
@@ -52,7 +52,7 @@ public class SimpleParameterInfoTests
         sut.SetName(name);
 
         // Assert
-        sut.Name.Should().Be(name);
+        sut.Name.ShouldBe(name);
     }
 
     [Theory]
@@ -66,7 +66,7 @@ public class SimpleParameterInfoTests
         var act = () => sut.SetName(name);
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"{nameof(SimpleParameterInfo.Name)} has a value and cannot be changed.");
+        act.ShouldThrow<InvalidOperationException>()
+           .Message.ShouldBe($"{nameof(SimpleParameterInfo.Name)} has a value and cannot be changed.");
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SqlFormatterTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Core/SqlFormatterTests.cs
@@ -16,7 +16,7 @@ public class SqlFormatterTests
         var result = sut.GetFormat(formatType);
 
         // Assert
-        result.Should().Be(sut);
+        result.ShouldBe(sut);
     }
 
     [Fact]
@@ -30,7 +30,7 @@ public class SqlFormatterTests
         var result = sut.GetFormat(formatType);
 
         // Assert
-        result.Should().BeNull();
+        result.ShouldBeNull();
     }
 
     [Fact]
@@ -59,11 +59,11 @@ public class SqlFormatterTests
         var result = sut.Format(null, formattableString, sut);
 
         // Assert
-        result.Should().Be(expectedResult);
-        sut.Parameters.ParameterNames.Should().HaveCount(3);
-        sut.Parameters.Get<int[]>("pc0_").Should().BeEquivalentTo(model.TypeIds);
-        sut.Parameters.Get<int>("p1").Should().Be(model.Id);
-        sut.Parameters.Get<int[]>("pc2_").Should().BeEquivalentTo(model.TypeIds);
+        result.ShouldBe(expectedResult);
+        sut.Parameters.ParameterNames.Count().ShouldBe(3);
+        sut.Parameters.Get<int[]>("pc0_").ShouldBe(model.TypeIds);
+        sut.Parameters.Get<int>("p1").ShouldBe(model.Id);
+        sut.Parameters.Get<int[]>("pc2_").ShouldBe(model.TypeIds);
     }
 
     [Theory]
@@ -79,7 +79,7 @@ public class SqlFormatterTests
         var result = sut.Format(Constants.RawFormat, argument, sut);
 
         // Assert
-        result.Should().Be(expectedResult);
+        result.ShouldBe(expectedResult);
     }
 
     [Theory]
@@ -95,9 +95,9 @@ public class SqlFormatterTests
         var result = sut.Format(null, argument, sut);
 
         // Assert
-        result.Should().Be("@p0");
-        sut.Parameters.ParameterNames.Should().HaveCount(1);
-        sut.Parameters.Get<object?>("p0").Should().Be(argument);
+        result.ShouldBe("@p0");
+        sut.Parameters.ParameterNames.Count().ShouldBe(1);
+        sut.Parameters.Get<object?>("p0").ShouldBe(argument);
     }
 
     [Theory]
@@ -115,9 +115,9 @@ public class SqlFormatterTests
         var result = sut.Format(null, parameterInfo, sut);
 
         // Assert
-        result.Should().Be("@p0");
-        sut.Parameters.ParameterNames.Should().HaveCount(1);
-        sut.Parameters.Get<object?>("p0").Should().Be(parameterInfo.Value);
+        result.ShouldBe("@p0");
+        sut.Parameters.ParameterNames.Count().ShouldBe(1);
+        sut.Parameters.Get<object?>("p0").ShouldBe(parameterInfo.Value);
     }
 
     [Fact]
@@ -144,14 +144,14 @@ public class SqlFormatterTests
         var result = sut.Format(null, formattableString, sut);
 
         // Assert
-        result.Should().Be(expectedResult);
-        sut.Parameters.ParameterNames.Should().HaveCount(6);
-        sut.Parameters.Get<int>("p0").Should().Be(model.Id);
-        sut.Parameters.Get<string>("p1").Should().Be(model.ProductName);
-        sut.Parameters.Get<double>("p2").Should().Be(model.Price.Value.As<double>());
-        sut.Parameters.Get<bool>("p3").Should().Be(model.IsActive);
-        sut.Parameters.Get<string?>("p4").Should().Be(model.SecondName);
-        sut.Parameters.Get<string?>("p5").Should().Be(model.SecondName);
+        result.ShouldBe(expectedResult);
+        sut.Parameters.ParameterNames.Count().ShouldBe(6);
+        sut.Parameters.Get<int>("p0").ShouldBe(model.Id);
+        sut.Parameters.Get<string>("p1").ShouldBe(model.ProductName);
+        sut.Parameters.Get<double>("p2").ShouldBe(model.Price.Value);
+        sut.Parameters.Get<bool>("p3").ShouldBe(model.IsActive);
+        sut.Parameters.Get<string?>("p4").ShouldBe(model.SecondName);
+        sut.Parameters.Get<string?>("p5").ShouldBe(model.SecondName);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class SqlFormatterTests
         sut.Reset();
 
         // Assert
-        sut.Parameters.ParameterNames.Should().BeEmpty();
+        sut.Parameters.ParameterNames.ShouldBeEmpty();
     }
 
     private static SqlFormatter CreateSqlFormatter(bool reuseParameters = false)

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Extensions/SimpleParameterInfoExtensionsTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/Extensions/SimpleParameterInfoExtensionsTests.cs
@@ -13,9 +13,9 @@ public class SimpleParameterInfoExtensionsTests
         Action act = () => value.DefineParam(DbType.Int64);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage($"Value is already a {nameof(ISimpleParameterInfo)}*")
-            .WithParameterName(nameof(value));
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldStartWith($"Value is already a {nameof(ISimpleParameterInfo)}");
+        exception.ParamName.ShouldBe(nameof(value));
     }
 
     [Theory]
@@ -26,11 +26,11 @@ public class SimpleParameterInfoExtensionsTests
         var valueParam = value.DefineParam(dbType, size, precision, scale);
 
         // Assert
-        valueParam.Should().BeOfType<SimpleParameterInfo>();
-        valueParam.Value.Should().Be(value);
-        valueParam.DbType.Should().Be(dbType);
-        valueParam.Size.Should().Be(size);
-        valueParam.Precision.Should().Be(precision);
-        valueParam.Scale.Should().Be(scale);
+        valueParam.ShouldBeOfType<SimpleParameterInfo>();
+        valueParam.Value.ShouldBe(value);
+        valueParam.DbType.ShouldBe(dbType);
+        valueParam.Size.ShouldBe(size);
+        valueParam.Precision.ShouldBe(precision);
+        valueParam.Scale.ShouldBe(scale);
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/DeleteBuilderTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/DeleteBuilderTests.cs
@@ -16,10 +16,10 @@ public class DeleteBuilderTests
             .DeleteFrom($"Table");
 
         // Assert
-        sut.Should().BeOfType<FluentSqlBuilder>();
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
-        sut.Parameters.Should().BeOfType<DynamicParameters>();
+        sut.ShouldBeOfType<FluentSqlBuilder>();
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
+        sut.Parameters.ShouldBeOfType<DynamicParameters>();
     }
 
     [Theory]
@@ -36,10 +36,10 @@ public class DeleteBuilderTests
             .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -56,10 +56,10 @@ public class DeleteBuilderTests
             .OrWhereFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -76,10 +76,10 @@ public class DeleteBuilderTests
                     .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -95,10 +95,10 @@ public class DeleteBuilderTests
                     .OrWhereFilter($"Id = {id}").WithOrFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -120,12 +120,12 @@ public class DeleteBuilderTests
             .OrWhere(true, $"Id NOT IN {ages}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(4);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<int[]>("pc1_").Should().BeEquivalentTo(ages);
-        sut.GetValue<string>("p2").Should().Be(type);
-        sut.GetValue<int[]>("pc3_").Should().BeEquivalentTo(ages);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(4);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<int[]>("pc1_").ShouldBe(ages);
+        sut.GetValue<string>("p2").ShouldBe(type);
+        sut.GetValue<int[]>("pc3_").ShouldBe(ages);
     }
 
     [Theory]
@@ -146,9 +146,9 @@ public class DeleteBuilderTests
             .Offset(5);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<int>("p0").Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<int>("p0").ShouldBe(id);
     }
 
     [Theory]
@@ -166,10 +166,10 @@ public class DeleteBuilderTests
             .Where($"TypeId IN ({subQuery})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -188,9 +188,9 @@ public class DeleteBuilderTests
             .Where($"TypeGroup IN ({subQuery})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<string>("p0").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<string>("p0").ShouldBe(type);
     }
 
     [Theory]
@@ -210,10 +210,10 @@ public class DeleteBuilderTests
             .OrWhereFilter($"Id = {idParam}").WithFilter($"Type = {typeParam}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -231,9 +231,9 @@ public class DeleteBuilderTests
         sut.AddParameter(nameof(id), id);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<int>(nameof(id)).Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<int>(nameof(id)).ShouldBe(id);
     }
 
     [Theory]
@@ -251,11 +251,11 @@ public class DeleteBuilderTests
             .Where($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -273,10 +273,10 @@ public class DeleteBuilderTests
             .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -293,11 +293,11 @@ public class DeleteBuilderTests
             .OrWhereFilter($"Age = {age}").WithFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Fact]
@@ -311,8 +311,8 @@ public class DeleteBuilderTests
         Action act = () => sut.InsertInto($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Insert}\" is not allowed after \"{ClauseAction.Delete}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+           .Message.ShouldBe($"Clause action \"{ClauseAction.Insert}\" is not allowed after \"{ClauseAction.Delete}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -326,8 +326,8 @@ public class DeleteBuilderTests
         Action act = () => sut.Select($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Select}\" is not allowed after \"{ClauseAction.Delete}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+           .Message.ShouldBe($"Clause action \"{ClauseAction.Select}\" is not allowed after \"{ClauseAction.Delete}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -341,8 +341,8 @@ public class DeleteBuilderTests
         Action act = () => sut.SelectDistinct($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.SelectDistinct}\" is not allowed after \"{ClauseAction.Delete}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+           .Message.ShouldBe($"Clause action \"{ClauseAction.SelectDistinct}\" is not allowed after \"{ClauseAction.Delete}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -356,7 +356,7 @@ public class DeleteBuilderTests
         Action act = () => sut.Update($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Update}\" is not allowed after \"{ClauseAction.Delete}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+           .Message.ShouldBe($"Clause action \"{ClauseAction.Update}\" is not allowed after \"{ClauseAction.Delete}\" has been initiated on the same Fluent Builder.");
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/DeleteInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/DeleteInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class DeleteInterpolatedStringHandlerTests
         Action act = () => _ = new DeleteInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class DeleteInterpolatedStringHandlerTests
         Action act = () => _ = new DeleteInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/GroupByInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/GroupByInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class GroupByInterpolatedStringHandlerTests
         Action act = () => _ = new GroupByInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class GroupByInterpolatedStringHandlerTests
         Action act = () => _ = new GroupByInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -48,7 +48,7 @@ public class GroupByInterpolatedStringHandlerTests
         var sut = new GroupByInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.GroupBy));
     }
 
@@ -68,7 +68,7 @@ public class GroupByInterpolatedStringHandlerTests
         var sut = new GroupByInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]
@@ -87,7 +87,7 @@ public class GroupByInterpolatedStringHandlerTests
         var sut = new GroupByInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/HavingInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/HavingInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class HavingInterpolatedStringHandlerTests
         Action act = () => _ = new HavingInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class HavingInterpolatedStringHandlerTests
         Action act = () => _ = new HavingInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -48,7 +48,7 @@ public class HavingInterpolatedStringHandlerTests
         var sut = new HavingInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.Having));
     }
 
@@ -68,7 +68,7 @@ public class HavingInterpolatedStringHandlerTests
         var sut = new HavingInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]
@@ -87,7 +87,7 @@ public class HavingInterpolatedStringHandlerTests
         var sut = new HavingInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/InnerJoinInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/InnerJoinInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class InnerJoinInterpolatedStringHandlerTests
         Action act = () => _ = new InnerJoinInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class InnerJoinInterpolatedStringHandlerTests
         Action act = () => _ = new InnerJoinInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class InnerJoinInterpolatedStringHandlerTests
         var sut = new InnerJoinInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.InnerJoin));
     }
 
@@ -60,7 +60,7 @@ public class InnerJoinInterpolatedStringHandlerTests
         _ = new InnerJoinInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/InsertColumnInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/InsertColumnInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class InsertColumnInterpolatedStringHandlerTests
         Action act = () => _ = new InsertColumnInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class InsertColumnInterpolatedStringHandlerTests
         Action act = () => _ = new InsertColumnInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/InsertInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/InsertInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class InsertInterpolatedStringHandlerTests
         Action act = () => _ = new InsertInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class InsertInterpolatedStringHandlerTests
         Action act = () => _ = new InsertInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/InsertValueInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/InsertValueInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class InsertValueInterpolatedStringHandlerTests
         Action act = () => _ = new InsertValueInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class InsertValueInterpolatedStringHandlerTests
         Action act = () => _ = new InsertValueInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/LeftJoinInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/LeftJoinInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class LeftJoinInterpolatedStringHandlerTests
         Action act = () => _ = new LeftJoinInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class LeftJoinInterpolatedStringHandlerTests
         Action act = () => _ = new LeftJoinInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class LeftJoinInterpolatedStringHandlerTests
         var sut = new LeftJoinInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.LeftJoin));
     }
 
@@ -59,7 +59,7 @@ public class LeftJoinInterpolatedStringHandlerTests
         _ = new LeftJoinInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/OrderByInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/OrderByInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class OrderByInterpolatedStringHandlerTests
         Action act = () => _ = new OrderByInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class OrderByInterpolatedStringHandlerTests
         Action act = () => _ = new OrderByInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -48,7 +48,7 @@ public class OrderByInterpolatedStringHandlerTests
         var sut = new OrderByInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.OrderBy));
     }
 
@@ -68,7 +68,7 @@ public class OrderByInterpolatedStringHandlerTests
         var sut = new OrderByInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]
@@ -87,7 +87,7 @@ public class OrderByInterpolatedStringHandlerTests
         var sut = new OrderByInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/RightJoinInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/RightJoinInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class RightJoinInterpolatedStringHandlerTests
         Action act = () => _ = new RightJoinInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class RightJoinInterpolatedStringHandlerTests
         Action act = () => _ = new RightJoinInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class RightJoinInterpolatedStringHandlerTests
         var sut = new RightJoinInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.RightJoin));
     }
 
@@ -60,7 +60,7 @@ public class RightJoinInterpolatedStringHandlerTests
         _ = new RightJoinInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/SelectDistinctInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/SelectDistinctInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class SelectDistinctInterpolatedStringHandlerTests
         Action act = () => _ = new SelectDistinctInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class SelectDistinctInterpolatedStringHandlerTests
         Action act = () => _ = new SelectDistinctInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/SelectFromInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/SelectFromInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class SelectFromInterpolatedStringHandlerTests
         Action act = () => _ = new SelectFromInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class SelectFromInterpolatedStringHandlerTests
         Action act = () => _ = new SelectFromInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/SelectInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/SelectInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class SelectInterpolatedStringHandlerTests
         Action act = () => _ = new SelectInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class SelectInterpolatedStringHandlerTests
         Action act = () => _ = new SelectInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/UpdateInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/UpdateInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class UpdateInterpolatedStringHandlerTests
         Action act = () => _ = new UpdateInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class UpdateInterpolatedStringHandlerTests
         Action act = () => _ = new UpdateInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/UpdateSetInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/UpdateSetInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class UpdateSetInterpolatedStringHandlerTests
         Action act = () => _ = new UpdateSetInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class UpdateSetInterpolatedStringHandlerTests
         Action act = () => _ = new UpdateSetInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class UpdateSetInterpolatedStringHandlerTests
         var sut = new UpdateSetInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.UpdateSet));
     }
 
@@ -60,7 +60,7 @@ public class UpdateSetInterpolatedStringHandlerTests
         _ = new UpdateSetInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereFilterInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereFilterInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class WhereFilterInterpolatedStringHandlerTests
         Action act = () => _ = new WhereFilterInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class WhereFilterInterpolatedStringHandlerTests
         Action act = () => _ = new WhereFilterInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class WhereInterpolatedStringHandlerTests
         Action act = () => _ = new WhereInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class WhereInterpolatedStringHandlerTests
         Action act = () => _ = new WhereInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class WhereInterpolatedStringHandlerTests
         var sut = new WhereInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.Where));
     }
 
@@ -60,7 +60,7 @@ public class WhereInterpolatedStringHandlerTests
         _ = new WhereInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereOrFilterInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereOrFilterInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class WhereOrFilterInterpolatedStringHandlerTests
         Action act = () => _ = new WhereOrFilterInterpolatedStringHandler(0, 0, fluentBuilder);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class WhereOrFilterInterpolatedStringHandlerTests
         Action act = () => _ = new WhereOrFilterInterpolatedStringHandler(0, 0, fluentBuilderMock.Object);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereOrInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereOrInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class WhereOrInterpolatedStringHandlerTests
         Action act = () => _ = new WhereOrInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class WhereOrInterpolatedStringHandlerTests
         Action act = () => _ = new WhereOrInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class WhereOrInterpolatedStringHandlerTests
         var sut = new WhereOrInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.WhereOr));
     }
 
@@ -60,7 +60,7 @@ public class WhereOrInterpolatedStringHandlerTests
         _ = new WhereOrInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereWithFilterInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereWithFilterInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class WhereWithFilterInterpolatedStringHandlerTests
         Action act = () => _ = new WhereWithFilterInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class WhereWithFilterInterpolatedStringHandlerTests
         Action act = () => _ = new WhereWithFilterInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class WhereWithFilterInterpolatedStringHandlerTests
         var sut = new WhereWithFilterInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.WhereWithFilter));
     }
 
@@ -60,7 +60,7 @@ public class WhereWithFilterInterpolatedStringHandlerTests
         _ = new WhereWithFilterInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereWithOrFilterInterpolatedStringHandlerTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/Handlers/WhereWithOrFilterInterpolatedStringHandlerTests.cs
@@ -15,9 +15,9 @@ public class WhereWithOrFilterInterpolatedStringHandlerTests
         Action act = () => _ = new WhereWithOrFilterInterpolatedStringHandler(0, 0, fluentBuilder, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -28,9 +28,9 @@ public class WhereWithOrFilterInterpolatedStringHandlerTests
         Action act = () => _ = new WhereWithOrFilterInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var _);
 
         // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("The builder must implement IFluentBuilderFormatter.*")
-            .WithParameterName("builder");
+        var exception = act.ShouldThrow<ArgumentException>();
+        exception.Message.ShouldMatch("The builder must implement IFluentBuilderFormatter.*");
+        exception.ParamName.ShouldBe("builder");
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class WhereWithOrFilterInterpolatedStringHandlerTests
         var sut = new WhereWithOrFilterInterpolatedStringHandler(0, 0, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeTrue();
+        isHandlerEnabled.ShouldBeTrue();
         fluentFormatterMock.Verify(x => x.StartClauseAction(ClauseAction.WhereWithOrFilter));
     }
 
@@ -60,7 +60,7 @@ public class WhereWithOrFilterInterpolatedStringHandlerTests
         _ = new InnerJoinInterpolatedStringHandler(0, 0, condition, fluentBuilderMock.Object, out var isHandlerEnabled);
 
         // Assert
-        isHandlerEnabled.Should().BeFalse();
+        isHandlerEnabled.ShouldBeFalse();
     }
 
     [Theory]

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/InsertBuilderTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/InsertBuilderTests.cs
@@ -19,13 +19,13 @@ public class InsertBuilderTests
             .Values($"{age}, {type}");
 
         // Assert
-        sut.Should().BeOfType<FluentSqlBuilder>();
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.Parameters.Should().BeOfType<DynamicParameters>();
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.ShouldBeOfType<FluentSqlBuilder>();
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.Parameters.ShouldBeOfType<DynamicParameters>();
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -44,11 +44,11 @@ public class InsertBuilderTests
             .Values($"{type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -66,11 +66,11 @@ public class InsertBuilderTests
             .Values($"{values}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -89,9 +89,9 @@ public class InsertBuilderTests
             .Values($"{values}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<int>("p0").Should().Be(age);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<int>("p0").ShouldBe(age);
     }
 
     [Theory]
@@ -112,10 +112,10 @@ public class InsertBuilderTests
             .Values($"{typeParam}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("@p0").Should().Be(id);
-        sut.GetValue<string>("@p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("@p0").ShouldBe(id);
+        sut.GetValue<string>("@p1").ShouldBe(type);
     }
 
     [Theory]
@@ -135,10 +135,10 @@ public class InsertBuilderTests
         sut.AddParameter(nameof(type), type);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>(nameof(id)).Should().Be(id);
-        sut.GetValue<string>(nameof(type)).Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>(nameof(id)).ShouldBe(id);
+        sut.GetValue<string>(nameof(type)).ShouldBe(type);
     }
 
     [Theory]
@@ -155,11 +155,11 @@ public class InsertBuilderTests
             .Values($"{age}, {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -175,10 +175,10 @@ public class InsertBuilderTests
             .Values($"{id}, {type}, {id}, {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -196,11 +196,11 @@ public class InsertBuilderTests
             .Values($"{type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Fact]
@@ -214,8 +214,8 @@ public class InsertBuilderTests
         Action act = () => sut.DeleteFrom($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Delete}\" is not allowed after \"{ClauseAction.Insert}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Delete}\" is not allowed after \"{ClauseAction.Insert}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -229,8 +229,8 @@ public class InsertBuilderTests
         Action act = () => sut.Select($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Select}\" is not allowed after \"{ClauseAction.Insert}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Select}\" is not allowed after \"{ClauseAction.Insert}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -244,8 +244,8 @@ public class InsertBuilderTests
         Action act = () => sut.SelectDistinct($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.SelectDistinct}\" is not allowed after \"{ClauseAction.Insert}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.SelectDistinct}\" is not allowed after \"{ClauseAction.Insert}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -259,7 +259,7 @@ public class InsertBuilderTests
         Action act = () => sut.Update($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Update}\" is not allowed after \"{ClauseAction.Insert}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Update}\" is not allowed after \"{ClauseAction.Insert}\" has been initiated on the same Fluent Builder.");
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/SelectBuilderTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/SelectBuilderTests.cs
@@ -17,10 +17,10 @@ public class SelectBuilderTests
                     .From($"Table");
 
         // Assert
-        sut.Should().BeOfType<FluentSqlBuilder>();
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
-        sut.Parameters.Should().BeOfType<DynamicParameters>();
+        sut.ShouldBeOfType<FluentSqlBuilder>();
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
+        sut.Parameters.ShouldBeOfType<DynamicParameters>();
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class SelectBuilderTests
                     .RightJoin($"Table4 ON Table1.Id = Table4.Id");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -68,8 +68,8 @@ public class SelectBuilderTests
                     .RightJoin(true, $"Table7 ON Table1.Id = Table7.Id");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Theory]
@@ -88,10 +88,10 @@ public class SelectBuilderTests
                     .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -109,10 +109,10 @@ public class SelectBuilderTests
                     .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -131,11 +131,11 @@ public class SelectBuilderTests
                         .WithOrFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -153,10 +153,10 @@ public class SelectBuilderTests
                     .OrWhereFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -179,11 +179,11 @@ public class SelectBuilderTests
                     .OrWhere(true, $"Id NOT IN (1, 2, 3)");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<int[]>("pc1_").Should().BeEquivalentTo(ages);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<int[]>("pc1_").ShouldBe(ages);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Fact]
@@ -201,8 +201,8 @@ public class SelectBuilderTests
                     .GroupBy($"{typeColumn:raw}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -220,8 +220,8 @@ public class SelectBuilderTests
                     .GroupBy(true, $"Type");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -242,8 +242,8 @@ public class SelectBuilderTests
                     .Having($"COUNT({typeColumn:raw}) < 100");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -264,8 +264,8 @@ public class SelectBuilderTests
                     .Having(true, $"COUNT(Type) < 100");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -283,8 +283,8 @@ public class SelectBuilderTests
                     .OrderBy($"{typeColumn:raw}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -302,8 +302,8 @@ public class SelectBuilderTests
                     .OrderBy(true, $"Type");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -323,8 +323,8 @@ public class SelectBuilderTests
                     .OffsetRows(offset);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -344,8 +344,8 @@ public class SelectBuilderTests
                     .FetchNext(rows);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -365,8 +365,8 @@ public class SelectBuilderTests
                     .Limit(rows);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -388,8 +388,8 @@ public class SelectBuilderTests
                     .Offset(offset);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Theory]
@@ -408,10 +408,10 @@ public class SelectBuilderTests
                     .Where($"TypeId IN ({subQuery})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -431,9 +431,9 @@ public class SelectBuilderTests
                     .Where($"TypeGroup IN ({subQuery})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<string>("p0").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<string>("p0").ShouldBe(type);
     }
 
     [Theory]
@@ -454,10 +454,10 @@ public class SelectBuilderTests
                     .OrWhereFilter($"Id = {idParam}").WithFilter($"Type = {typeParam}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -476,9 +476,9 @@ public class SelectBuilderTests
         sut.AddParameter(nameof(id), id);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<int>(nameof(id)).Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<int>(nameof(id)).ShouldBe(id);
     }
 
     [Theory]
@@ -497,11 +497,11 @@ public class SelectBuilderTests
                     .Where($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -520,10 +520,10 @@ public class SelectBuilderTests
                     .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -560,11 +560,11 @@ public class SelectBuilderTests
                     .FetchNext(rows);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Fact]
@@ -586,8 +586,8 @@ public class SelectBuilderTests
                     .Offset(offset);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -601,8 +601,8 @@ public class SelectBuilderTests
         Action act = () => sut.DeleteFrom($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Delete}\" is not allowed after \"{ClauseAction.Select}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Delete}\" is not allowed after \"{ClauseAction.Select}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -616,8 +616,8 @@ public class SelectBuilderTests
         Action act = () => sut.InsertInto($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Insert}\" is not allowed after \"{ClauseAction.Select}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Insert}\" is not allowed after \"{ClauseAction.Select}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -631,8 +631,8 @@ public class SelectBuilderTests
         Action act = () => sut.SelectDistinct($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.SelectDistinct}\" is not allowed after \"{ClauseAction.Select}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.SelectDistinct}\" is not allowed after \"{ClauseAction.Select}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -646,7 +646,7 @@ public class SelectBuilderTests
         Action act = () => sut.Update($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Update}\" is not allowed after \"{ClauseAction.Select}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Update}\" is not allowed after \"{ClauseAction.Select}\" has been initiated on the same Fluent Builder.");
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/SelectDistinctBuilderTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/SelectDistinctBuilderTests.cs
@@ -17,10 +17,10 @@ public class SelectDistinctBuilderTests
                     .From($"Table");
 
         // Assert
-        sut.Should().BeOfType<FluentSqlBuilder>();
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
-        sut.Parameters.Should().BeOfType<DynamicParameters>();
+        sut.ShouldBeOfType<FluentSqlBuilder>();
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
+        sut.Parameters.ShouldBeOfType<DynamicParameters>();
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class SelectDistinctBuilderTests
                     .RightJoin($"Table4 ON Table1.Id = Table4.Id");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -68,8 +68,8 @@ public class SelectDistinctBuilderTests
                     .RightJoin(true, $"Table7 ON Table1.Id = Table7.Id");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Theory]
@@ -88,10 +88,10 @@ public class SelectDistinctBuilderTests
                     .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -109,10 +109,10 @@ public class SelectDistinctBuilderTests
                     .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -131,11 +131,11 @@ public class SelectDistinctBuilderTests
                         .WithOrFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -153,10 +153,10 @@ public class SelectDistinctBuilderTests
                     .OrWhereFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -179,11 +179,11 @@ public class SelectDistinctBuilderTests
                     .OrWhere(true, $"Id NOT IN (1, 2, 3)");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<int[]>("pc1_").Should().BeEquivalentTo(ages);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<int[]>("pc1_").ShouldBe(ages);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Fact]
@@ -201,8 +201,8 @@ public class SelectDistinctBuilderTests
                     .GroupBy($"{typeColumn:raw}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -220,8 +220,8 @@ public class SelectDistinctBuilderTests
                     .GroupBy(true, $"Type");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -242,8 +242,8 @@ public class SelectDistinctBuilderTests
                     .Having($"COUNT({typeColumn:raw}) < 100");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -264,8 +264,8 @@ public class SelectDistinctBuilderTests
                     .Having(true, $"COUNT(Type) < 100");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -283,8 +283,8 @@ public class SelectDistinctBuilderTests
                     .OrderBy($"{typeColumn:raw}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -302,8 +302,8 @@ public class SelectDistinctBuilderTests
                     .OrderBy(true, $"Type");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -323,8 +323,8 @@ public class SelectDistinctBuilderTests
                     .OffsetRows(offset);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -344,8 +344,8 @@ public class SelectDistinctBuilderTests
                     .FetchNext(rows);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -365,8 +365,8 @@ public class SelectDistinctBuilderTests
                     .Limit(rows);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -388,8 +388,8 @@ public class SelectDistinctBuilderTests
                     .Offset(offset);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Theory]
@@ -408,10 +408,10 @@ public class SelectDistinctBuilderTests
                     .Where($"TypeId IN ({subQuery})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -431,9 +431,9 @@ public class SelectDistinctBuilderTests
                     .Where($"TypeGroup IN ({subQuery})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<string>("p0").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<string>("p0").ShouldBe(type);
     }
 
     [Theory]
@@ -454,10 +454,10 @@ public class SelectDistinctBuilderTests
                     .OrWhereFilter($"Id = {idParam}").WithFilter($"Type = {typeParam}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -476,9 +476,9 @@ public class SelectDistinctBuilderTests
         sut.AddParameter(nameof(id), id);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<int>(nameof(id)).Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<int>(nameof(id)).ShouldBe(id);
     }
 
     [Theory]
@@ -497,11 +497,11 @@ public class SelectDistinctBuilderTests
                     .Where($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -520,10 +520,10 @@ public class SelectDistinctBuilderTests
                     .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -560,11 +560,11 @@ public class SelectDistinctBuilderTests
                     .FetchNext(rows);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Fact]
@@ -586,8 +586,8 @@ public class SelectDistinctBuilderTests
                     .Offset(offset);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(0);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldBeEmpty();
     }
 
     [Fact]
@@ -601,8 +601,8 @@ public class SelectDistinctBuilderTests
         Action act = () => sut.DeleteFrom($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Delete}\" is not allowed after \"{ClauseAction.SelectDistinct}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Delete}\" is not allowed after \"{ClauseAction.SelectDistinct}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -616,8 +616,8 @@ public class SelectDistinctBuilderTests
         Action act = () => sut.InsertInto($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Insert}\" is not allowed after \"{ClauseAction.SelectDistinct}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Insert}\" is not allowed after \"{ClauseAction.SelectDistinct}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -631,8 +631,8 @@ public class SelectDistinctBuilderTests
         Action act = () => sut.Select($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Select}\" is not allowed after \"{ClauseAction.SelectDistinct}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Select}\" is not allowed after \"{ClauseAction.SelectDistinct}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -646,7 +646,7 @@ public class SelectDistinctBuilderTests
         Action act = () => sut.Update($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Update}\" is not allowed after \"{ClauseAction.SelectDistinct}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Update}\" is not allowed after \"{ClauseAction.SelectDistinct}\" has been initiated on the same Fluent Builder.");
     }
 }

--- a/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/UpdateBuilderTests.cs
+++ b/src/Tests/UnitTests/SimpleSqlBuilder.UnitTests/FluentBuilder/UpdateBuilderTests.cs
@@ -19,13 +19,13 @@ public class UpdateBuilderTests
             .Set($"Age = {age}, Type = {type}");
 
         // Assert
-        sut.Should().BeOfType<FluentSqlBuilder>();
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.Parameters.Should().BeOfType<DynamicParameters>();
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.ShouldBeOfType<FluentSqlBuilder>();
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.Parameters.ShouldBeOfType<DynamicParameters>();
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -43,10 +43,10 @@ public class UpdateBuilderTests
             .Set(true, $"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -65,12 +65,12 @@ public class UpdateBuilderTests
             .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(4);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<string>("p1").Should().Be(type);
-        sut.GetValue<int>("p2").Should().Be(id);
-        sut.GetValue<string>("p3").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(4);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<string>("p1").ShouldBe(type);
+        sut.GetValue<int>("p2").ShouldBe(id);
+        sut.GetValue<string>("p3").ShouldBe(type);
     }
 
     [Theory]
@@ -89,12 +89,12 @@ public class UpdateBuilderTests
             .OrWhereFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(4);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<string>("p1").Should().Be(type);
-        sut.GetValue<int>("p2").Should().Be(id);
-        sut.GetValue<string>("p3").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(4);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<string>("p1").ShouldBe(type);
+        sut.GetValue<int>("p2").ShouldBe(id);
+        sut.GetValue<string>("p3").ShouldBe(type);
     }
 
     [Theory]
@@ -112,11 +112,11 @@ public class UpdateBuilderTests
                     .OrWhere($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<int>("p1").Should().Be(id);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<int>("p1").ShouldBe(id);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -133,11 +133,11 @@ public class UpdateBuilderTests
                     .OrWhereFilter($"Id = {id}").WithOrFilter($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(3);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<int>("p1").Should().Be(id);
-        sut.GetValue<string>("p2").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(3);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<int>("p1").ShouldBe(id);
+        sut.GetValue<string>("p2").ShouldBe(type);
     }
 
     [Theory]
@@ -160,14 +160,14 @@ public class UpdateBuilderTests
             .OrWhere(true, $"Id = {id}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(6);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
-        sut.GetValue<int[]>("pc3_").Should().BeEquivalentTo(ages);
-        sut.GetValue<string>("p4").Should().Be(type);
-        sut.GetValue<int>("p5").Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(6);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
+        sut.GetValue<int[]>("pc3_").ShouldBe(ages);
+        sut.GetValue<string>("p4").ShouldBe(type);
+        sut.GetValue<int>("p5").ShouldBe(id);
     }
 
     [Theory]
@@ -185,10 +185,10 @@ public class UpdateBuilderTests
             .Where($"TypeId IN ({subQuery})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -207,9 +207,9 @@ public class UpdateBuilderTests
             .Where($"TypeGroup IN ({subQuery})");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(1);
-        sut.GetValue<string>("p0").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.ShouldHaveSingleItem();
+        sut.GetValue<string>("p0").ShouldBe(type);
     }
 
     [Theory]
@@ -230,10 +230,10 @@ public class UpdateBuilderTests
             .Where($"Type = {typeParam}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<string>("p0").Should().Be(type);
-        sut.GetValue<int>("p1").Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<string>("p0").ShouldBe(type);
+        sut.GetValue<int>("p1").ShouldBe(id);
     }
 
     [Theory]
@@ -253,10 +253,10 @@ public class UpdateBuilderTests
         sut.AddParameter(nameof(type), type);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>(nameof(id)).Should().Be(id);
-        sut.GetValue<string>(nameof(type)).Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>(nameof(id)).ShouldBe(id);
+        sut.GetValue<string>(nameof(type)).ShouldBe(type);
     }
 
     [Theory]
@@ -278,10 +278,10 @@ public class UpdateBuilderTests
             .FetchNext(10);
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(age);
-        sut.GetValue<int>("p1").Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(age);
+        sut.GetValue<int>("p1").ShouldBe(id);
     }
 
     [Theory]
@@ -298,12 +298,12 @@ public class UpdateBuilderTests
             .Where($"Id = {id}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(4);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<string>("p2").Should().Be(type);
-        sut.GetValue<int>("p3").Should().Be(id);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(4);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<string>("p2").ShouldBe(type);
+        sut.GetValue<int>("p3").ShouldBe(id);
     }
 
     [Theory]
@@ -322,10 +322,10 @@ public class UpdateBuilderTests
             .Where($"Type = {type}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(2);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<string>("p1").Should().Be(type);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(2);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<string>("p1").ShouldBe(type);
     }
 
     [Theory]
@@ -343,13 +343,13 @@ public class UpdateBuilderTests
             .OrWhereFilter($"Type = {type}").WithFilter($"Age = {age}");
 
         // Assert
-        sut.Sql.Should().Be(expectedSql);
-        sut.ParameterNames.Should().HaveCount(5);
-        sut.GetValue<int>("p0").Should().Be(id);
-        sut.GetValue<int>("p1").Should().Be(age);
-        sut.GetValue<int>("p2").Should().Be(id);
-        sut.GetValue<string>("p3").Should().Be(type);
-        sut.GetValue<int>("p4").Should().Be(age);
+        sut.Sql.ShouldBe(expectedSql);
+        sut.ParameterNames.Count().ShouldBe(5);
+        sut.GetValue<int>("p0").ShouldBe(id);
+        sut.GetValue<int>("p1").ShouldBe(age);
+        sut.GetValue<int>("p2").ShouldBe(id);
+        sut.GetValue<string>("p3").ShouldBe(type);
+        sut.GetValue<int>("p4").ShouldBe(age);
     }
 
     [Fact]
@@ -363,8 +363,8 @@ public class UpdateBuilderTests
         Action act = () => sut.DeleteFrom($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Delete}\" is not allowed after \"{ClauseAction.Update}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Delete}\" is not allowed after \"{ClauseAction.Update}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -378,8 +378,8 @@ public class UpdateBuilderTests
         Action act = () => sut.InsertInto($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Insert}\" is not allowed after \"{ClauseAction.Update}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Insert}\" is not allowed after \"{ClauseAction.Update}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -393,8 +393,8 @@ public class UpdateBuilderTests
         Action act = () => sut.Select($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.Select}\" is not allowed after \"{ClauseAction.Update}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.Select}\" is not allowed after \"{ClauseAction.Update}\" has been initiated on the same Fluent Builder.");
     }
 
     [Fact]
@@ -408,7 +408,7 @@ public class UpdateBuilderTests
         Action act = () => sut.SelectDistinct($"*");
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Clause action \"{ClauseAction.SelectDistinct}\" is not allowed after \"{ClauseAction.Update}\" has been initiated on the same Fluent Builder.");
+        act.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldBe($"Clause action \"{ClauseAction.SelectDistinct}\" is not allowed after \"{ClauseAction.Update}\" has been initiated on the same Fluent Builder.");
     }
 }


### PR DESCRIPTION
﻿<!--Provide a concise title to the pull request as it will be used for the release documentation.-->

## Description

Refactored unit tests to use `Shouldly` and removed `FluentAssertions`.

## Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🔥 Hotfix (a major bugfix that has to be merged asap)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠 Enhancements (improvements to existing features)
- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [x] 📦 Other change

## Checklist
<!-- Ensure you have completed the checklist-->
- [x] My change follows the guidelines outlined in the [contributing](https://github.com/mishael-o/Dapper.SimpleSqlBuilder/blob/main/docs/CONTRIBUTING.md) document.
